### PR TITLE
Resolve middleware server status from availability metric

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/collector/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/collector/middleware_manager.rb
@@ -45,8 +45,11 @@ module ManageIQ::Providers
       connection.inventory.get_config_data_for_resource(resource_path)
     end
 
-    def metrics_for_metric_type(metric_path)
-      connection.inventory.list_metrics_for_metric_type(metric_path)
+    def metrics_for_metric_type(feed, metric_type_id)
+      metric_type_path = ::Hawkular::Inventory::CanonicalPath.new(
+        :metric_type_id => metric_type_id, :feed_id => feed
+      )
+      connection.inventory.list_metrics_for_metric_type(metric_type_path)
     end
 
     def raw_availability_data(*args)

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_deployment.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_deployment.rb
@@ -1,4 +1,14 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::MiddlewareDeployment < MiddlewareDeployment
+    def self.resource_path_for_metrics(item)
+      path = ::Hawkular::Inventory::CanonicalPath.parse(item.ems_ref)
+      # for subdeployments use it's parent deployment availability.
+      path = path.up if path.resource_ids.last.include? CGI.escape('/subdeployment=')
+      # Ensure consistency on keys (resource_path) used on metric_id_by_resource_path
+      path = ::Hawkular::Inventory::CanonicalPath.new(:tenant_id    => path.tenant_id,
+                                                      :feed_id      => path.feed_id,
+                                                      :resource_ids => path.resource_ids)
+      path.to_s
+    end
   end
 end

--- a/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_manager_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_manager_spec.rb
@@ -18,7 +18,14 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareManager do
                        :zone            => zone)
   end
   let(:persister) { ::ManageIQ::Providers::Hawkular::Inventory::Persister::MiddlewareManager.new(ems_hawkular, ems_hawkular) }
-  let(:parser) { described_class.new }
+  let(:collector_double) { instance_double('ManageIQ::Providers::Hawkular::Inventory::Collector::MiddlewareManager') }
+  let(:persister_double) { instance_double('ManageIQ::Providers::Hawkular::Inventory::Persister::MiddlewareManager') }
+  let(:parser) do
+    parser = described_class.new
+    parser.collector = collector_double
+    parser.persister = persister_double
+    parser
+  end
   let(:server) do
     FactoryGirl.create(:hawkular_middleware_server,
                        :name                  => 'Local',
@@ -97,79 +104,119 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareManager do
     end
   end
 
-  describe 'parse_availability' do
-    it 'handles simple data' do
-      resources_by_metric_id = {
-        'resource_id_1' => [{}],
-        'resource_id_2' => [{}, {}],
-        'resource_id_3' => [{}],
-        'resource_id_4' => [{}]
-      }
-      availabilities = [
-        {
-          'id'   => 'resource_id_1',
-          'data' => [{ 'value' => 'up' }]
-        },
-        {
-          'id'   => 'resource_id_2',
-          'data' => [{ 'value' => 'down' }]
-        },
-        {
-          'id'   => 'resource_id_3',
-          'data' => [{ 'value' => 'something_else' }]
-        },
-        {
-          'id'   => 'resource_id_4',
-          'data' => []
-        }
-      ]
+  describe 'fetch_availabilities_for' do
+    let(:stubbed_resource) { OpenStruct.new(:manager_uuid => '/t;hawkular/f;f1/r;stubbed_resource') }
+    let(:stubbed_metric_definition) { OpenStruct.new(:path => '/t;hawkular/f;f1/r;stubbed_resource/m;m1', :hawkular_metric_id => 'm1') }
+    let(:stubbed_metric_data) { OpenStruct.new(:id => 'm1', :data => [{'timestamp' => 1, 'value' => 'arbitrary value'}]) }
 
-      parsed_resources_with_availability = {
-        'resource_id_1' => [{
-          :status => 'Enabled'
-        }],
-        'resource_id_2' => [
-          {
-            :status => 'Disabled'
-          },
-          {
-            :status => 'Disabled'
-          }
-        ],
-        'resource_id_3' => [{
-          :status => 'Unknown'
-        }],
-        'resource_id_4' => [{
-          :status => 'Unknown'
-        }]
-      }
-      expect(parser.parse_availability(availabilities, resources_by_metric_id))
-        .to eq(parsed_resources_with_availability)
+    before do
+      allow(collector_double).to receive(:metrics_for_metric_type).and_return([])
+      allow(collector_double).to receive(:metrics_for_metric_type)
+        .with('f1', 'metric_type')
+        .and_return([stubbed_metric_definition])
+      allow(collector_double).to receive(:raw_availability_data)
+        .with(%w(m1), hash_including(:order => 'DESC'))
+        .and_return([stubbed_metric_data])
     end
-    it 'handles missing metrics' do
-      resources_by_metric_id = {
-        'resource_id_1' => [{}],
-        'resource_id_2' => [{}],
-        'resource_id_3' => [{}],
-        'resource_id_4' => [{}],
-      }
-      availabilities = [
-        {
-          'id'   => 'resource_id_1',
-          'data' => [{ 'value' => 'up' }]
-        }
-      ]
 
-      parsed_resources_with_availability = {
-        'resource_id_1' => [{
-          :status => 'Enabled'
-        }],
-        'resource_id_2' => [{}],
-        'resource_id_3' => [{}],
-        'resource_id_4' => [{}]
-      }
-      expect(parser.parse_availability(availabilities, resources_by_metric_id))
-        .to eq(parsed_resources_with_availability)
+    def call_subject(feeds = %w(f1), resources = [stubbed_resource])
+      matched_metrics = {}
+      parser.fetch_availabilities_for(feeds, resources, 'metric_type') do |resource, metric|
+        matched_metrics[resource] = metric
+      end
+
+      matched_metrics
+    end
+
+    it 'must query collector for metrics for every feed' do
+      expect(collector_double).to receive(:metrics_for_metric_type).with('f1', 'metric_type')
+      expect(collector_double).to receive(:metrics_for_metric_type).with('f2', 'metric_type')
+
+      parser.fetch_availabilities_for(%w(f2 f1), [], 'metric_type')
+    end
+
+    it 'must call block with missing metrics to allow caller to set defaults' do
+      stubbed_resource.manager_uuid += 'idsuffix'
+
+      matched_metrics = call_subject
+      expect(matched_metrics).to eq(stubbed_resource => nil)
+    end
+
+    it 'must call block with matching resource and metric to allow caller to process the metric' do
+      matched_metrics = call_subject
+      expect(matched_metrics).to eq(stubbed_resource => stubbed_metric_data)
+    end
+
+    it 'must call block handling a metric shared by more than one resource' do
+      stubbed_resource2 = OpenStruct.new(:manager_uuid => '/t;hawkular/f;f1/r;stubbed_resource2')
+      stubbed_metric_definition2 = OpenStruct.new(:path => '/t;hawkular/f;f1/r;stubbed_resource2/m;m1', :hawkular_metric_id => 'm1')
+
+      expect(collector_double).to receive(:metrics_for_metric_type)
+        .with('f1', 'metric_type')
+        .and_return([stubbed_metric_definition, stubbed_metric_definition2])
+
+      matched_metrics = call_subject(%w(f1), [stubbed_resource, stubbed_resource2])
+      expect(matched_metrics).to eq(stubbed_resource => stubbed_metric_data, stubbed_resource2 => stubbed_metric_data)
+    end
+
+    it 'must call block handling resources in more than one feed' do
+      stubbed_resource2 = OpenStruct.new(:manager_uuid => '/t;hawkular/f;another_feed/r;stubbed_resource')
+      stubbed_metric_definition2 = OpenStruct.new(:path => '/t;hawkular/f;another_feed/r;stubbed_resource/m;m2', :hawkular_metric_id => 'm2')
+      stubbed_metric_data2 = OpenStruct.new(:id => 'm2', :data => [{'timestamp' => 1, 'value' => 'other value'}])
+
+      expect(collector_double).to receive(:metrics_for_metric_type)
+        .with('another_feed', 'metric_type')
+        .and_return([stubbed_metric_definition2])
+      expect(collector_double).to receive(:raw_availability_data)
+        .with(%w(m1 m2), hash_including(:order => 'DESC'))
+        .and_return([stubbed_metric_data, stubbed_metric_data2])
+
+      matched_metrics = call_subject(%w(another_feed f1), [stubbed_resource, stubbed_resource2])
+      expect(matched_metrics).to eq(stubbed_resource => stubbed_metric_data, stubbed_resource2 => stubbed_metric_data2)
+    end
+  end
+
+  describe 'fetch_deployment_availabilities' do
+    let(:stubbed_deployment) { OpenStruct.new(:manager_uuid => '/t;hawkular/f;f1/r;s1/r;d1') }
+    let(:stubbed_metric_data) { OpenStruct.new(:id => 'm1', :data => [{'timestamp' => 1, 'value' => 'up'}]) }
+
+    before do
+      allow(persister_double).to receive(:middleware_deployments).and_return([stubbed_deployment])
+      allow(parser).to receive(:fetch_availabilities_for)
+        .and_yield(stubbed_deployment, stubbed_metric_data)
+    end
+
+    it 'uses fetch_availabilities_for to fetch deployment availabilities' do
+      parser.fetch_deployment_availabilities(%w(f1))
+      expect(parser).to have_received(:fetch_availabilities_for)
+        .with(%w(f1), [stubbed_deployment], 'Deployment%20Status~Deployment%20Status')
+    end
+
+    it 'assigns enabled status to a deployment with "up" metric' do
+      parser.fetch_deployment_availabilities(%w(f1))
+      expect(stubbed_deployment.status).to eq('Enabled')
+    end
+
+    it 'assigns disabled status to a deployment with "down" metric' do
+      stubbed_metric_data.data.first['value'] = 'down'
+
+      parser.fetch_deployment_availabilities(%w(f1))
+      expect(stubbed_deployment.status).to eq('Disabled')
+    end
+
+    it 'assigns unknown status to a deployment whose metric is something else than "up" or "down"' do
+      stubbed_metric_data.data.first['value'] = 'this is arbitrary value'
+
+      parser.fetch_deployment_availabilities(%w(f1))
+      expect(stubbed_deployment.status).to eq('Unknown')
+    end
+
+    it 'assigns unknown status to a deployment with a missing metric' do
+      allow(parser).to receive(:fetch_availabilities_for)
+        .and_yield(stubbed_deployment, nil)
+
+      parser.fetch_deployment_availabilities(%w(f1))
+      expect(stubbed_deployment.status).to eq('Unknown')
     end
   end
 

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
@@ -36,6 +36,10 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
     expect(@ems_hawkular.middleware_datasources).not_to be_empty
     expect(@ems_hawkular.middleware_messagings).not_to be_empty
     expect(@ems_hawkular.middleware_deployments.first).to have_attributes(:status => 'Enabled')
+    expect(@ems_hawkular.middleware_servers.first.properties).to have_attributes(
+      'Availability'            => 'unknown',
+      'Calculated Server State' => 'unknown'
+    )
     assert_specific_datasource(@ems_hawkular, 'Local~/subsystem=datasources/data-source=ExampleDS')
     assert_specific_datasource(@ems_hawkular,
                                'Local~/host=master/server=s/subsystem=datasources/data-source=ExampleDS')

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher.yml
@@ -4008,4 +4008,212 @@ http_interactions:
         Status~Deployment Status","data":[{"timestamp":1489687110001,"value":"up"}]}]'
     http_version: 
   recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/mt;Server%20Availability~Server%20Availability/rl;defines/type=m
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.2.6p396
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 10 Apr 2017 17:24:46 GMT
+      X-Total-Count:
+      - '0'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/mt;Server%20Availability~Server%20Availability/rl;defines/type=m>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: "[ ]"
+    http_version: 
+  recorded_at: Mon, 10 Apr 2017 17:24:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/mt;Server%20Availability~Server%20Availability/rl;defines/type=m
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.2.6p396
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 10 Apr 2017 17:24:46 GMT
+      X-Total-Count:
+      - '3'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3354'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/mt;Server%20Availability~Server%20Availability/rl;defines/type=m>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/m;AI~R~%5Bmaster.Unnamed%20Domain%2FLocal~%2Fhost%3Dmaster%2Fserver%3Dserver-two%5D~AT~Server%20Availability~Server%20Availability",
+          "name" : "Server Availability",
+          "identityHash" : "3b7688ff641fc2b1fcfcc30c516135682514e7",
+          "contentHash" : "b8266da4a29e7b776ecadafb395ec9b9d54a527e",
+          "syncHash" : "49b465b9653f167666a186ad623168c144ba779",
+          "type" : {
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/mt;Server%20Availability~Server%20Availability",
+            "name" : "Server Availability",
+            "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
+            "contentHash" : "6a4899a2f3f17eebaa41bc8535b1d55b177ed5",
+            "syncHash" : "eb1bd0737685952db2cf013326b98647edcd63",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 30,
+            "type" : "AVAILABILITY",
+            "id" : "Server Availability~Server Availability"
+          },
+          "id" : "AI~R~[master.Unnamed Domain/Local~/host=master/server=server-two]~AT~Server Availability~Server Availability"
+        }, {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/m;AI~R~%5Bmaster.Unnamed%20Domain%2FLocal~%2Fhost%3Dmaster%2Fserver%3Dserver-one%5D~AT~Server%20Availability~Server%20Availability",
+          "name" : "Server Availability",
+          "identityHash" : "2ad2814354612d53cfb7aa9f137de1572304938",
+          "contentHash" : "b8266da4a29e7b776ecadafb395ec9b9d54a527e",
+          "syncHash" : "159b77f7c9a75ddc2f1b1fd2cb7e41fd21d3",
+          "type" : {
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/mt;Server%20Availability~Server%20Availability",
+            "name" : "Server Availability",
+            "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
+            "contentHash" : "6a4899a2f3f17eebaa41bc8535b1d55b177ed5",
+            "syncHash" : "eb1bd0737685952db2cf013326b98647edcd63",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 30,
+            "type" : "AVAILABILITY",
+            "id" : "Server Availability~Server Availability"
+          },
+          "id" : "AI~R~[master.Unnamed Domain/Local~/host=master/server=server-one]~AT~Server Availability~Server Availability"
+        }, {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-three/m;AI~R~%5Bmaster.Unnamed%20Domain%2FLocal~%2Fhost%3Dmaster%2Fserver%3Dserver-three%5D~AT~Server%20Availability~Server%20Availability",
+          "name" : "Server Availability",
+          "identityHash" : "2ba6266b74c5e2edc333457d92351bb6b0d9b6",
+          "contentHash" : "b8266da4a29e7b776ecadafb395ec9b9d54a527e",
+          "syncHash" : "4b8b5b4e24388448c7d192029946d59901a606e",
+          "type" : {
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/mt;Server%20Availability~Server%20Availability",
+            "name" : "Server Availability",
+            "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
+            "contentHash" : "6a4899a2f3f17eebaa41bc8535b1d55b177ed5",
+            "syncHash" : "eb1bd0737685952db2cf013326b98647edcd63",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 30,
+            "type" : "AVAILABILITY",
+            "id" : "Server Availability~Server Availability"
+          },
+          "id" : "AI~R~[master.Unnamed Domain/Local~/host=master/server=server-three]~AT~Server Availability~Server Availability"
+        } ]
+    http_version: 
+  recorded_at: Mon, 10 Apr 2017 17:24:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/mt;Deployment%20Status~Deployment%20Status/rl;defines/type=m
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.2.6p396
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 10 Apr 2017 17:24:46 GMT
+      X-Total-Count:
+      - '0'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/mt;Deployment%20Status~Deployment%20Status/rl;defines/type=m>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: "[ ]"
+    http_version: 
+  recorded_at: Mon, 10 Apr 2017 17:24:46 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Server status was being fetched from inventory's data resulting in wrong
reported status when server is down. Now, server status is resolved with
a combination of server's availability metric and its inventory status.

https://bugzilla.redhat.com/show_bug.cgi?id=1438816

This PR goes together with manageiq/manageiq-ui-classic#987. Merge order is not important and is not required to merge simultaneously.