### PR TITLE
Don't attempt to query Hawkular if no metrics were provided

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
@@ -54,6 +54,7 @@ module ManageIQ::Providers
     end
 
     def collect_stats_metrics(metrics, start_time, end_time, interval)
+      return [{}, {}] if metrics.empty?
       gauge_ids, counter_ids, avail_ids, metrics_ids_map = parse_metrics_ids(metrics)
       starts = start_time.to_i.in_milliseconds
       ends = (end_time + interval).to_i.in_milliseconds + 1


### PR DESCRIPTION
Hawkular returns with an error status code if an empty list of metrics
is sent in the query. Indeed, it doesn't make sense to query the
hawkular server if no metrics were requested and, instead, an empty
object can be returned.

One use case where this method is used, is when generating performance
reports for middleware servers. If there is one server that has never been
in running state or has been down for a "long" time, it may not have any
metrics (all them may have expired and purged). If this happens, the
"metrics" argument of collect_stats_metrics will be empty.

https://bugzilla.redhat.com/show_bug.cgi?id=1445702