### PR TITLE
Avoid trigger id collisions when Hawkular is linked to multiple MiQ installations

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -432,6 +432,10 @@ module ManageIQ::Providers
       )
     end
 
+    def miq_id_prefix(id_to_prefix = "")
+      "MiQ-region-#{miq_region.guid}-ems-#{guid}-#{id_to_prefix}"
+    end
+
     def self.update_alert(*args)
       operation = args[0][:operation]
       alert = args[0][:alert]
@@ -460,11 +464,11 @@ module ManageIQ::Providers
     end
 
     def alert_manager
-      @alert_manager ||= ManageIQ::Providers::Hawkular::MiddlewareManager::AlertManager.new(alerts_client)
+      @alert_manager ||= ManageIQ::Providers::Hawkular::MiddlewareManager::AlertManager.new(self)
     end
 
     def alert_profile_manager
-      @alert_profile_manager ||= ManageIQ::Providers::Hawkular::MiddlewareManager::AlertProfileManager.new(alerts_client)
+      @alert_profile_manager ||= ManageIQ::Providers::Hawkular::MiddlewareManager::AlertProfileManager.new(self)
     end
 
     private

--- a/spec/factories/miq_alert.rb
+++ b/spec/factories/miq_alert.rb
@@ -2,4 +2,23 @@ FactoryGirl.define do
   factory :miq_alert_middleware, :parent => :miq_alert do
     db "MiddlewareServer"
   end
+
+  factory :miq_alert_mw_heap_used, :parent => :miq_alert_middleware do
+    description "Jvm Heap Used Alert"
+    options(
+      :notifications => {
+        :delay_next_evaluation => 60,
+        :evm_event             => { }
+      }
+    )
+    expression(
+      :eval_method => 'mw_heap_used',
+      :mode        => 'internal',
+      :options     => {
+        :value_mw_greater_than => 90,
+        :value_mw_less_than    => 10
+      }
+    )
+    responds_to_events 'hawkular_alert'
+  end
 end

--- a/spec/factories/miq_alert.rb
+++ b/spec/factories/miq_alert.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :miq_alert_middleware, :parent => :miq_alert do
+    db "MiddlewareServer"
+  end
+end

--- a/spec/factories/miq_alert_set.rb
+++ b/spec/factories/miq_alert_set.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :miq_alert_set_mw, :parent => :miq_alert_set do
+    mode "MiddlewareServer"
+  end
+end

--- a/spec/integration/alert_mgmt_flows_spec.rb
+++ b/spec/integration/alert_mgmt_flows_spec.rb
@@ -1,0 +1,257 @@
+require_relative '../models/manageiq/providers/hawkular/middleware_manager/hawkular_helper'
+
+describe "Alert mgmt flow:" do
+  let(:alert) { FactoryGirl.create(:miq_alert_mw_heap_used, :id => 201) }
+
+  subject!(:ems) do
+    ems = ems_hawkular_fixture
+    ems.guid = "def"
+    ems.save!
+    ems
+  end
+
+  before do
+    MiqRegion.seed
+    MiqRegion.my_region.guid = "abc"
+    MiqRegion.my_region.save!
+    @hwclient = nil
+  end
+
+  around do |ex|
+    vcr_opts = ex.metadata[:vcr]
+
+    cassette_name = vcr_opts.delete(:cassette_name)
+    cassette_name = "integration/alert_mgmt_flows/#{cassette_name}"
+
+    VCR.use_cassette(cassette_name, vcr_opts, &ex)
+  end
+
+  def ems_class
+    ManageIQ::Providers::Hawkular::MiddlewareManager
+  end
+
+  def alert_manager_class
+    ManageIQ::Providers::Hawkular::MiddlewareManager::AlertManager
+  end
+
+  def hawkular_client
+    @hclient ||= Hawkular::Client.new(
+      :credentials => {
+        :username => test_userid,
+        :password => test_password
+      },
+      :options     => { :tenant => 'hawkular' },
+      :entrypoint  => URI::HTTP.build(:host => test_hostname, :port => test_port)
+    )
+  end
+
+  def alerts_client
+    hawkular_client.alerts
+  end
+
+  describe "alerts" do
+    it "CRUD flow is propagated to Hawkular", :vcr => { :cassette_name => 'alerts_crud_flow' } do
+      # STAGE 1
+      # Notify to EMS an alert was created
+      ems_class.update_alert(:operation => :new, :alert => alert)
+
+      # Verify a trigger is in Hawkular
+      hawkular_alert_id = alert_manager_class.build_hawkular_trigger_id(:ems => ems, :alert => alert)
+      trigger = alerts_client.list_triggers(hawkular_alert_id)
+      expect(trigger.count).to eq(1)
+
+      # STAGE 2
+      # Update alert condition and notify to EMS
+      alert.expression[:options][:value_mw_greater_than] = 50
+      alert.save
+      ems_class.update_alert(:operation => :update, :alert => alert)
+
+      # Verify trigger condition was updated in Hawkular
+      trigger = alerts_client.get_single_trigger(hawkular_alert_id, true)
+      expect(trigger.conditions.count).to eq(2)
+
+      updated_condition = trigger.conditions.find { |c| c.operator == 'GT' }
+      expect(updated_condition.data2_multiplier).to eq(0.5)
+
+      # STAGE 3
+      # Delete alert and notify to EMS
+      alert.destroy
+      ems_class.update_alert(:operation => :delete, :alert => alert)
+
+      # Verify trigger has been deleted in Hawkular
+      trigger = alerts_client.list_triggers(hawkular_alert_id)
+      expect(trigger.count).to be_zero
+    end
+
+    it "should fallback to old alerts id format if an alert with the new id does not exist in Hawkular",
+       :vcr => { :cassette_name => 'fallback_to_old_ids_format' } do
+      # Temporarily mock construction of id
+      allow(alert_manager_class).to receive(:build_hawkular_trigger_id).and_return("MiQ-#{alert.id}")
+
+      # Create alert in Hawkular with old id format
+      ems_class.update_alert(:operation => :new, :alert => alert)
+
+      trigger = alerts_client.list_triggers("MiQ-#{alert.id}")
+      expect(trigger.count).to eq(1)
+
+      # Remove mock
+      allow(alert_manager_class).to receive(:build_hawkular_trigger_id).and_call_original
+      expect(alert_manager_class.build_hawkular_trigger_id(:ems => ems, :alert => { :id => 1 })).to include('ems') # just to check mock is removed
+
+      # Delete alert and notify to EMS
+      alert.destroy
+      ems_class.update_alert(:operation => :delete, :alert => alert)
+
+      # Verify trigger has been deleted in Hawkular
+      trigger = alerts_client.list_triggers("MiQ-#{alert.id}")
+      expect(trigger.count).to be_zero
+    end
+  end
+
+  describe "alert profiles" do
+    # This context assumes that there is a wildfly server
+    # in domain mode (with the shipped sample domain configs)
+    # connected to hawkular services. This means that hawkular
+    # should have registered the relevant inventory entities.
+
+    let(:profile) { FactoryGirl.create(:miq_alert_set_mw, :id => 202) }
+    let(:server_one) do
+      s1 = ManageIQ::Providers::Hawkular::MiddlewareManager::
+        MiddlewareServer.find_by(:name => 'server-one')
+      s1.update_column(:id, 400)
+      s1.reload
+    end
+
+    before do
+      VCR.use_cassette('integration/alert_mgmt_flows/profiles_hawkular_setup') do # , :record => :all) do
+        # Update MiQ inventory
+        EmsRefresh.refresh(ems)
+        ems.reload
+
+        # Place group trigger in Hawkular
+        ems_class.update_alert(:operation => :new, :alert => alert)
+        alert.reload
+      end
+    end
+
+    after do
+      VCR.use_cassette('integration/alert_mgmt_flows/profiles_hawkular_cleanup') do # , :record => :all) do
+        # Cleanup group trigger in Hawkular
+        ems_class.update_alert(:operation => :delete, :alert => alert)
+      end
+    end
+
+    it "without assigned servers shouldn't create members in Hawkular when adding alerts",
+       :vcr => { :cassette_name => 'add_alerts_to_profile_with_no_servers' } do
+      # Setup
+      profile.add_member(alert)
+
+      ems_class.update_alert_profile(
+        :operation       => :update_alerts,
+        :profile_id      => profile.id,
+        :old_alerts      => [],
+        :new_alerts      => [alert.id],
+        :old_assignments => [],
+        :new_assignments => nil
+      )
+
+      # Verify
+      triggers = alerts_client.list_triggers
+      expect(triggers.select { |t| t.type == 'MEMBER' }.count).to be_zero
+    end
+
+    it "without alerts shouldn't create members in Hawkular when adding servers",
+       :vcr => { :cassette_name => 'add_servers_to_profile_with_no_alerts' } do
+      # Setup
+      profile.assign_to_objects([server_one])
+
+      ems_class.update_alert_profile(
+        :operation       => :update_assignments,
+        :profile_id      => profile.id,
+        :old_alerts      => [],
+        :new_alerts      => [],
+        :old_assignments => [],
+        :new_assignments => {"objects" => [server_one.id], "assign_to" => server_one.class}
+      )
+
+      # Verify
+      triggers = alerts_client.list_triggers
+      expect(triggers.select { |t| t.type == 'MEMBER' }.count).to be_zero
+    end
+
+    it "with alerts should update members in Hawkular when assigning and unassigning a server",
+       :vcr => { :cassette_name => 'assign_unassign_server_to_profile_with_alerts' } do
+      # Setup
+      profile.add_member(alert)
+
+      # Add the server
+      profile.assign_to_objects([server_one])
+
+      ems_class.update_alert_profile(
+        :operation       => :update_assignments,
+        :profile_id      => profile.id,
+        :old_alerts      => [alert.id],
+        :new_alerts      => [],
+        :old_assignments => [],
+        :new_assignments => {"objects" => [server_one.id], "assign_to" => server_one.class}
+      )
+
+      # Verify
+      triggers = alerts_client.list_triggers
+      expect(triggers.select { |t| t.type == 'MEMBER' }.count).to eq(1)
+
+      # Remove server
+      profile.remove_all_assigned_tos
+
+      ems_class.update_alert_profile(
+        :operation       => :update_assignments,
+        :profile_id      => profile.id,
+        :old_alerts      => [alert.id],
+        :new_alerts      => [],
+        :old_assignments => [server_one],
+        :new_assignments => nil
+      )
+
+      # Verify
+      triggers = alerts_client.list_triggers
+      expect(triggers.select { |t| t.type == 'MEMBER' }.count).to be_zero
+    end
+
+    it "with servers should update members in Hawkular when assigning and unassigning an alert",
+       :vcr => { :cassette_name => 'assign_unassign_alert_to_profile_with_servers' } do
+      # Setup
+      profile.assign_to_objects([server_one])
+
+      # Add the alert
+      profile.add_member(alert)
+      ems_class.update_alert_profile(
+        :operation       => :update_alerts,
+        :profile_id      => profile.id,
+        :old_alerts      => [],
+        :new_alerts      => [alert.id],
+        :old_assignments => [server_one],
+        :new_assignments => nil
+      )
+
+      # Verify
+      triggers = alerts_client.list_triggers
+      expect(triggers.select { |t| t.type == 'MEMBER' }.count).to eq(1)
+
+      # Remove the alert
+      profile.remove_member(alert)
+
+      ems_class.update_alert_profile(
+        :operation       => :update_alerts,
+        :profile_id      => profile.id,
+        :old_alerts      => [alert.id],
+        :new_alerts      => [],
+        :old_assignments => [server_one],
+        :new_assignments => nil
+      )
+
+      # Verify
+      triggers = alerts_client.list_triggers
+      expect(triggers.select { |t| t.type == 'MEMBER' }.count).to be_zero
+    end
+  end
+end

--- a/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_manager_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_manager_spec.rb
@@ -7,15 +7,7 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareManager do
       .slice(*inventory_object.inventory_collection.inventory_object_attributes)
   end
 
-  let(:ems_hawkular) do
-    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    auth = AuthToken.new(:name => "test", :auth_key => "valid-token", :userid => "jdoe", :password => "password")
-    FactoryGirl.create(:ems_hawkular,
-                       :hostname        => 'localhost',
-                       :port            => 8080,
-                       :authentications => [auth],
-                       :zone            => zone)
-  end
+  let(:ems_hawkular) { ems_hawkular_fixture }
   let(:persister) { ::ManageIQ::Providers::Hawkular::Inventory::Persister::MiddlewareManager.new(ems_hawkular, ems_hawkular) }
   let(:collector_double) { instance_double('ManageIQ::Providers::Hawkular::Inventory::Collector::MiddlewareManager') }
   let(:persister_double) { instance_double('ManageIQ::Providers::Hawkular::Inventory::Persister::MiddlewareManager') }

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/hawkular_helper.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/hawkular_helper.rb
@@ -5,11 +5,11 @@ def the_feed_id
 end
 
 def test_start_time
-  Time.new(2016, 10, 19, 8, 00, 0, "+00:00").freeze
+  Time.new(2016, 10, 19, 8, 0, 0, "+00:00").freeze
 end
 
 def test_end_time
-  Time.new(2016, 10, 19, 10, 00, 0, "+00:00").freeze
+  Time.new(2016, 10, 19, 10, 0, 0, "+00:00").freeze
 end
 
 def test_hostname
@@ -28,4 +28,14 @@ end
 
 def test_password
   'password'.freeze
+end
+
+def ems_hawkular_fixture
+  _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+  auth = AuthToken.new(:name => "test", :auth_key => "valid-token", :userid => "jdoe", :password => "password")
+  FactoryGirl.create(:ems_hawkular,
+                     :hostname        => test_hostname,
+                     :port            => test_port,
+                     :authentications => [auth],
+                     :zone            => zone)
 end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager_spec.rb
@@ -6,4 +6,42 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager do
   it ".description" do
     expect(described_class.description).to eq('Hawkular')
   end
+
+  describe "miq_id_prefix" do
+    let(:random_id) { SecureRandom.hex(10) }
+    let!(:my_region) do
+      MiqRegion.my_region || FactoryGirl.create(:miq_region, :region => MiqRegion.my_region_number)
+    end
+    let(:random_region) do
+      region = Random.rand(1..99) while !region || region == my_region.region
+      MiqRegion.find_by(:region => region) || FactoryGirl.create(:miq_region, :region => region)
+    end
+
+    it "must return non-empty string" do
+      rval = subject.miq_id_prefix
+      expect(rval.to_s.strip).not_to be_empty
+    end
+
+    it "must prefix the provided string/identifier" do
+      rval = subject.miq_id_prefix(random_id)
+
+      expect(rval).to end_with(random_id)
+      expect(rval).not_to eq(random_id)
+    end
+
+    it "must generate different prefixes for different providers" do
+      ems_a = FactoryGirl.create(:ems_hawkular)
+      ems_b = FactoryGirl.create(:ems_hawkular)
+
+      expect(ems_a.miq_id_prefix).not_to eq(ems_b.miq_id_prefix)
+    end
+
+    it "must generate different prefixes for same provider on different MiQ region" do
+      ems_a = FactoryGirl.create(:ems_hawkular)
+      ems_b = ems_a.dup
+      ems_b.id = described_class.id_in_region(ems_a.id % described_class::DEFAULT_RAILS_SEQUENCE_FACTOR, random_region.region)
+
+      expect(ems_a.miq_id_prefix).not_to eq(ems_b.miq_id_prefix)
+    end
+  end
 end

--- a/spec/vcr_cassettes/integration/alert_mgmt_flows/add_alerts_to_profile_with_no_servers.yml
+++ b/spec/vcr_cassettes/integration/alert_mgmt_flows/add_alerts_to_profile_with_no_servers.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '531'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers>; rel="current", <http://localhost:8080/hawkular/alerts/triggers?page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/integration/alert_mgmt_flows/add_servers_to_profile_with_no_alerts.yml
+++ b/spec/vcr_cassettes/integration/alert_mgmt_flows/add_servers_to_profile_with_no_alerts.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '531'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers>; rel="current", <http://localhost:8080/hawkular/alerts/triggers?page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/integration/alert_mgmt_flows/alerts_crud_flow.yml
+++ b/spec/vcr_cassettes/integration/alert_mgmt_flows/alerts_crud_flow.yml
@@ -1,0 +1,664 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups
+    body:
+      encoding: UTF-8
+      string: '{"id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm Heap Used Alert","enabled":true,"eventType":"EVENT","description":"Jvm
+        Heap Used Alert","context":{"dataId.hm.type":"gauge","dataId.hm.prefix":"hm_g_"},"type":"GROUP","tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"firingMatch":"ANY","actions":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '335'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '529'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.type":"gauge","dataId.hm.prefix":"hm_g_"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: put
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201/conditions/FIRING
+    body:
+      encoding: UTF-8
+      string: '{"conditions":[{"conditionId":null,"type":"COMPARE","operator":"GT","threshold":null,"triggerMode":"FIRING","dataId":"WildFly
+        Memory Metrics~Heap Used","data2Id":"WildFly Memory Metrics~Heap Max","data2Multiplier":0.9,"triggerId":null,"interval":null},{"conditionId":null,"type":"COMPARE","operator":"LT","threshold":null,"triggerMode":"FIRING","dataId":"WildFly
+        Memory Metrics~Heap Used","data2Id":"WildFly Memory Metrics~Heap Max","data2Multiplier":0.1,"triggerId":null,"interval":null}],"dataIdMemberMap":{}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '511'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '699'
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-1","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"GT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.9},{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-2","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"LT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.1}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '531'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201>;
+        rel="current", <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201&page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '531'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201>;
+        rel="current", <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201&page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: put
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201/
+    body:
+      encoding: UTF-8
+      string: '{"id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm Heap Used Alert","enabled":true,"eventType":"EVENT","description":"Jvm
+        Heap Used Alert","context":{"dataId.hm.type":"gauge","dataId.hm.prefix":"hm_g_"},"type":"GROUP","tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"firingMatch":"ANY","actions":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '335'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '529'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: put
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201/conditions/FIRING
+    body:
+      encoding: UTF-8
+      string: '{"conditions":[{"conditionId":null,"type":"COMPARE","operator":"GT","threshold":null,"triggerMode":"FIRING","dataId":"WildFly
+        Memory Metrics~Heap Used","data2Id":"WildFly Memory Metrics~Heap Max","data2Multiplier":0.5,"triggerId":null,"interval":null},{"conditionId":null,"type":"COMPARE","operator":"LT","threshold":null,"triggerMode":"FIRING","dataId":"WildFly
+        Memory Metrics~Heap Used","data2Id":"WildFly Memory Metrics~Heap Max","data2Multiplier":0.1,"triggerId":null,"interval":null}],"dataIdMemberMap":{}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '511'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '699'
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-1","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"GT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.5},{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-2","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"LT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.1}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '529'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '699'
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-1","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"GT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.5},{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-2","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"LT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.1}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '531'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201>;
+        rel="current", <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201&page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: delete
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/integration/alert_mgmt_flows/assign_unassign_alert_to_profile_with_servers.yml
+++ b/spec/vcr_cassettes/integration/alert_mgmt_flows/assign_unassign_alert_to_profile_with_servers.yml
@@ -1,0 +1,960 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '531'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201>;
+        rel="current", <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201&page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '529'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '699'
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-1","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"GT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.9},{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-2","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"LT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.1}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: put
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201/
+    body:
+      encoding: UTF-8
+      string: '{"id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm Heap Used Alert","enabled":true,"severity":"MEDIUM","autoResolve":false,"autoResolveAlerts":true,"eventType":"EVENT","description":"Jvm
+        Heap Used Alert","autoEnable":false,"autoDisable":false,"context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202"},"type":"GROUP","tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"firingMatch":"ANY","autoResolveMatch":"ALL","tenantId":"hawkular","actions":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '513'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '556'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201/members?includeOrphans=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/members
+    body:
+      encoding: UTF-8
+      string: '{"groupId":"MiQ-region-abc-ems-def-alert-201","memberId":"MiQ-region-abc-ems-def-alert-201-400","memberName":"Jvm
+        Heap Used Alert for server-one","memberDescription":null,"memberContext":{"resource_path":"/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one"},"memberTags":null,"dataIdMap":{"WildFly
+        Memory Metrics~Heap Used":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Used","WildFly Memory Metrics~Heap Max":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Max"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '653'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1068'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201-400","name":"Jvm
+        Heap Used Alert for server-one","description":"Jvm Heap Used Alert","type":"MEMBER","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"miq.alert_profiles":"202","dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","resource_path":"/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"WildFly
+        Memory Metrics~Heap Used":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Used","WildFly Memory Metrics~Heap Max":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Max"},"memberOf":"MiQ-region-abc-ems-def-alert-201","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      X-Total-Count:
+      - '2'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1627'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers>; rel="current", <http://localhost:8080/hawkular/alerts/triggers?page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201-400","name":"Jvm
+        Heap Used Alert for server-one","description":"Jvm Heap Used Alert","type":"MEMBER","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202","resource_path":"/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"WildFly
+        Memory Metrics~Heap Max":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Max","WildFly Memory Metrics~Heap Used":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Used"},"memberOf":"MiQ-region-abc-ems-def-alert-201","enabled":true,"firingMatch":"ANY","source":"_none_"},{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '558'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201>;
+        rel="current", <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201&page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '556'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '699'
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-1","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"GT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.9},{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-2","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"LT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.1}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:28 GMT
+- request:
+    method: put
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201/
+    body:
+      encoding: UTF-8
+      string: '{"id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm Heap Used Alert","enabled":true,"severity":"MEDIUM","autoResolve":false,"autoResolveAlerts":true,"eventType":"EVENT","description":"Jvm
+        Heap Used Alert","autoEnable":false,"autoDisable":false,"context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":""},"type":"GROUP","tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"firingMatch":"ANY","autoResolveMatch":"ALL","tenantId":"hawkular","actions":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '510'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:28 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:29 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:29 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '553'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":""},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:29 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/members/MiQ-region-abc-ems-def-alert-201-400/orphan
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:29 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:29 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201-400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:29 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1068'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201-400","name":"Jvm
+        Heap Used Alert for server-one","description":"Jvm Heap Used Alert","type":"ORPHAN","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202","resource_path":"/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"WildFly
+        Memory Metrics~Heap Max":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Max","WildFly Memory Metrics~Heap Used":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Used"},"memberOf":"MiQ-region-abc-ems-def-alert-201","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:29 GMT
+- request:
+    method: delete
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201-400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:29 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:29 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:29 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '555'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers>; rel="current", <http://localhost:8080/hawkular/alerts/triggers?page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":""},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/integration/alert_mgmt_flows/assign_unassign_server_to_profile_with_alerts.yml
+++ b/spec/vcr_cassettes/integration/alert_mgmt_flows/assign_unassign_server_to_profile_with_alerts.yml
@@ -1,0 +1,960 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '531'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201>;
+        rel="current", <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201&page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '529'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '699'
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-1","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"GT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.9},{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-2","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"LT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.1}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: put
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201/
+    body:
+      encoding: UTF-8
+      string: '{"id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm Heap Used Alert","enabled":true,"severity":"MEDIUM","autoResolve":false,"autoResolveAlerts":true,"eventType":"EVENT","description":"Jvm
+        Heap Used Alert","autoEnable":false,"autoDisable":false,"context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202"},"type":"GROUP","tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"firingMatch":"ANY","autoResolveMatch":"ALL","tenantId":"hawkular","actions":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '513'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '556'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201/members?includeOrphans=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/members
+    body:
+      encoding: UTF-8
+      string: '{"groupId":"MiQ-region-abc-ems-def-alert-201","memberId":"MiQ-region-abc-ems-def-alert-201-400","memberName":"Jvm
+        Heap Used Alert for server-one","memberDescription":null,"memberContext":{"resource_path":"/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one"},"memberTags":null,"dataIdMap":{"WildFly
+        Memory Metrics~Heap Used":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Used","WildFly Memory Metrics~Heap Max":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Max"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '653'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1068'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201-400","name":"Jvm
+        Heap Used Alert for server-one","description":"Jvm Heap Used Alert","type":"MEMBER","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"miq.alert_profiles":"202","dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","resource_path":"/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"WildFly
+        Memory Metrics~Heap Used":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Used","WildFly Memory Metrics~Heap Max":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Max"},"memberOf":"MiQ-region-abc-ems-def-alert-201","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      X-Total-Count:
+      - '2'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1627'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers>; rel="current", <http://localhost:8080/hawkular/alerts/triggers?page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201-400","name":"Jvm
+        Heap Used Alert for server-one","description":"Jvm Heap Used Alert","type":"MEMBER","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202","resource_path":"/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"WildFly
+        Memory Metrics~Heap Max":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Max","WildFly Memory Metrics~Heap Used":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Used"},"memberOf":"MiQ-region-abc-ems-def-alert-201","enabled":true,"firingMatch":"ANY","source":"_none_"},{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '558'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201>;
+        rel="current", <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201&page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '556'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '699'
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-1","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"GT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.9},{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-2","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"LT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.1}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: put
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201/
+    body:
+      encoding: UTF-8
+      string: '{"id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm Heap Used Alert","enabled":true,"severity":"MEDIUM","autoResolve":false,"autoResolveAlerts":true,"eventType":"EVENT","description":"Jvm
+        Heap Used Alert","autoEnable":false,"autoDisable":false,"context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":""},"type":"GROUP","tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"firingMatch":"ANY","autoResolveMatch":"ALL","tenantId":"hawkular","actions":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '510'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '553'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":""},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/members/MiQ-region-abc-ems-def-alert-201-400/orphan
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201-400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1068'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201-400","name":"Jvm
+        Heap Used Alert for server-one","description":"Jvm Heap Used Alert","type":"ORPHAN","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":"202","resource_path":"/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"WildFly
+        Memory Metrics~Heap Max":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Max","WildFly Memory Metrics~Heap Used":"hm_g_MI~R~[master.Unnamed%2520Domain/Local~/host=master/server=server-one]~MT~WildFly
+        Memory Metrics~Heap Used"},"memberOf":"MiQ-region-abc-ems-def-alert-201","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: delete
+    uri: http://localhost:8080/hawkular/alerts/triggers/MiQ-region-abc-ems-def-alert-201-400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:30 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '555'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers>; rel="current", <http://localhost:8080/hawkular/alerts/triggers?page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge","miq.alert_profiles":""},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:30 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/integration/alert_mgmt_flows/fallback_to_old_ids_format.yml
+++ b/spec/vcr_cassettes/integration/alert_mgmt_flows/fallback_to_old_ids_format.yml
@@ -1,0 +1,304 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups
+    body:
+      encoding: UTF-8
+      string: '{"id":"MiQ-201","name":"Jvm Heap Used Alert","enabled":true,"eventType":"EVENT","description":"Jvm
+        Heap Used Alert","context":{"dataId.hm.type":"gauge","dataId.hm.prefix":"hm_g_"},"type":"GROUP","tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"firingMatch":"ANY","actions":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '310'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '504'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-201","name":"Jvm Heap Used Alert","description":"Jvm
+        Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.type":"gauge","dataId.hm.prefix":"hm_g_"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: put
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-201/conditions/FIRING
+    body:
+      encoding: UTF-8
+      string: '{"conditions":[{"conditionId":null,"type":"COMPARE","operator":"GT","threshold":null,"triggerMode":"FIRING","dataId":"WildFly
+        Memory Metrics~Heap Used","data2Id":"WildFly Memory Metrics~Heap Max","data2Multiplier":0.9,"triggerId":null,"interval":null},{"conditionId":null,"type":"COMPARE","operator":"LT","threshold":null,"triggerMode":"FIRING","dataId":"WildFly
+        Memory Metrics~Heap Used","data2Id":"WildFly Memory Metrics~Heap Max","data2Multiplier":0.1,"triggerId":null,"interval":null}],"dataIdMemberMap":{}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '511'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '599'
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","triggerId":"MiQ-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"hawkular-MiQ-201-FIRING-2-1","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"GT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.9},{"tenantId":"hawkular","triggerId":"MiQ-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"hawkular-MiQ-201-FIRING-2-2","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"LT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.1}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '506'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-201>; rel="current",
+        <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-201&page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-201","name":"Jvm Heap Used Alert","description":"Jvm
+        Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: delete
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:27 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/integration/alert_mgmt_flows/profiles_hawkular_cleanup.yml
+++ b/spec/vcr_cassettes/integration/alert_mgmt_flows/profiles_hawkular_cleanup.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '531'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201>;
+        rel="current", <http://localhost:8080/hawkular/alerts/triggers?triggerIds=MiQ-region-abc-ems-def-alert-201&page=0>;
+        rel="last"
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.prefix":"hm_g_","dataId.hm.type":"gauge"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: delete
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/integration/alert_mgmt_flows/profiles_hawkular_setup.yml
+++ b/spec/vcr_cassettes/integration/alert_mgmt_flows/profiles_hawkular_setup.yml
@@ -1,0 +1,12413 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/metrics/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAA3MvQ7CIBiF4XthFsJfK3Fr1aqDizTulH5NSIA2QF2M9y7T
+        WZ7zftETSnI2a0gfZwGdkB6713i9oAN6hM1DgFhMcWvEb0i5biWU8JYwMrho
+        fHX97nzBQ1oDvrmC9b1jFclmYlJZJSTMLadMLawRlgumjpOUojUgOVUL1MDZ
+        5GzinEy97Rv6/QHfcrqrlgAAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/metrics/strings/tags/module:inventory,feed:*
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '89'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKtWSktNTVGyilaySDUwTDZNNUw1N0xU0lHKTSwuSS3SC83L
+        S8xNTVFwyc9NzMxTigVK5KeU5qSCdGTmlaXmleQXVSrF1gIAlG4OQUgAAAA=
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,restypes:.*\\|WildFly\\
+        Server\\|.*"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '123'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local%20JMX~org\\.hawkular:type%3dhawkular\\-javaagent"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '461'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAADWRy3KiQABFf2WKbTLKU8CqLEABAVFeKpLKooVGkHcDjZDK
+        fPu4yd2dzTmL+/lNZDGxJrIKw6qv0bQQIElFHKQgT4EFWuzrCBR/DCv4V6P7
+        IgVjPhQArfupgR+/9PcBMAD3l4B4J2LQA2L9+U30WQm7HpQNsaZYUeAohmR4
+        QSTfCQyKAb6iO7bTpd/taMcn8daRtyomm6ughr3JZh6bq0oH9PtFlWr7Ot3A
+        rV2VHuPTl7oWbhZ/4Q7ZdglOlS9ymCnw9Tn1ueeOS2+M0MnVcvrNohQsal14
+        zrTZFZVRlspy4vayotYRQmELo2sw2I6zt1G/TGzyGBhsx9rWAw6S0J6fNJUo
+        PJJUMwU5cMKA5MUmFAdDiCBGvNnG6ZQWkerR272Z0kUQn9zDORmNsFW4xE3p
+        0n6KMavJ9cxsdI60644dV1O/a+pjUK84mEcVSO1TaHLN3tCeetVHZVUKR3gD
+        G86cjttBkXjv6Yk2M79p1RyFj2los8fIFZZTVqQJT3MYe5LsCml8mPMjvTqL
+        LOYb3z+g3rC8gKWb0RSVt00CEw1ZvhEhdRfSAoZBg3P54Go6leqb1wsfxM/X
+        z9d/jToBcRYCAAA=
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:rt"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '88'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6571'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO16x47kWpbkryRyy0JRqwJ6Qa21dDYaA2rSnU4tvdH/Psz3
+        qrqmZxCdmbOaxQRiFfBA3LBjx47Zufdf//17W3z/2/e238t+Hebrr1QJwTle
+        wiUJp3+d17+65XtYy298uaxtn67t0H+ztjUbtr745g35q1y/sW1ftH39/S/f
+        i3RNv//tX//9+9q+719I3+P3v8EYTeEwCmEwDCF/+b6n3Vbef1HGFoX5x5ca
+        OX40CwZzifOpQZ+6e0fhPMzilCJJmJTSASvIqDtJKjcjR8IQDg5KYBV2TCVi
+        vy/no95bLiP46yG+aVGIHzrCnyGbB4vrQ+V7gxpLttei05JAgY6QrBBHkxH7
+        LXgHgEXLKZAKIG9D0ajcUGyCDWjwCjksoJ3+W4spnd5Hsx7IqnWvkPRGYo/6
+        6yW5EY7xlWU9o0tCK/Pqi0HfafZRMEsFsm8foLKnsFkwwmKbPiZrDJbeHJDZ
+        qBQyVD6QKYQmoQIU4PUG5qVCOjKjdqtkMpgyuABVZZQMYbTEH0RD7rVwA/Uv
+        //L9P/7tP/7y86pt/Y8SfDPYMu1/UhiUJHD6i8LIsONEM+8wH6pd5USn2vMl
+        GLznCdb+cPJTHGGxf3QKsprPSq42fJeaxEFU5PXifesp+Zd9cg/CTDM1CjXu
+        4xwInb05qGVVOYG0WRPFg9TXMB496uO+VtOvEfQkfekAgjkEldKlPuxzfJLC
+        i6DcT4GU1wttZCmbZp6APBEX2nWB8zfCfvqRni1AsNErFClKMzdYF+SjzJ2+
+        fkeUpSgF7O2fOMSKHUbW6DhOaaZBhCgVLplOfZAPyy6TrAsaLToPYkdNvSfa
+        y5viso9Bu+M+RrylVso4DPNrRVCledjG5ed9gX4Fv4iYjjPzBnMIIKF9Ypyx
+        OztLK4N/KE2AvUapgxr+oum59tA1Tfqi9i8WUPB9oHwfTjRMuY4OgVWiRgwH
+        xvzhcBQsOuEx1KbBXV94zBhzURVnsOvplhefczw51H+0aBpbXhXqMq1pnhj3
+        bSnh6Gdv2SZDAobf0qCbQWBbdB+3hYtcfpz2F7n5X1Xj2x8g/RwjGPuSou6F
+        /ElRMbU++8XLUKdenrNbc+kdpDQUUBa+EgkZjIpESS0ZiYf9UqUMeqsSxNiC
+        igR+/3m65IVNR5Tz7yVwnZ7z5hNFRN1x+/mdyJ0rh5xWcnDzGDpztEB+TSmI
+        yVt7f0deZI+Pqqj18vOakNjpPv2iVk1bz5ALjewrXV9djLcKvjYUmeUFoIkK
+        GCZ9Ih44RmGbRD170SJUeueuNKS2XN4g8NWtNjOlC6w/WTNVYqAVG+zcxmtB
+        Mq1xt2JGUGD7iIlaGnZNomhMh8wemNSR+X194tWHuTWEBMGDODtBJlbjYn5H
+        Q/5O329ck/Z92f28RPiXJULcIxh4w+Wk+IpfPVcN/mNU2CAciCCgTsnP5aB+
+        P3xt1JcN2KD3+phiRLSJhCtA8EMdKeEwrzYt11wOPalyJ/ipd/R7kl7tQCJy
+        OK560Zaf4nMtHBeoY/oUsirZwN0ywxyWJ8hl+dQyX4r4A8CRc5rV3PP7vwhV
+        czstJpkUg6DUh5AU2oyDL+JWEeIgpEsMLqjwTAEALDatn/EiPKpMe8q4tTrt
+        wc3nBX4SWh8+iUVQOVykpV8dW/P07ICh3Ah7qs9Q3iSaD5HNvLSescGHvYLc
+        Mn+gvfL8joFxwH5aAiQ8bqW3q+ol2MlLKkyH/fWWsrt0rYb5/T/secjLZRnm
+        n2o+CRNfio71v4lORbPJQC7xI22nQ/VsffTkF0nGbEPrvjGv6eLlzo6LJq23
+        2fpmTSF5+CTXFE4mahDGZw5Tue+THgPvPbhdTcYONtC3cJfxpuFLOQkzG0EF
+        XvdUWcXQlpKBRn2uQb4Sg2iaspuM2j+xk8Cwuor0tsM57qk94vVDAoCXc+Bq
+        1L8hQKrhffOHsc1/SmkIhb8CCTUPp/8BkgiJkfYZsVoifScgL2YJgqnlgudF
+        BE1iVykmmhbWw/TgWspO1e9yut56OPqNFQgWNFWD2HZp4IAEx4gcYmYhM01C
+        kW7XIXVoj9AwVsbOLMRW5FFuoS4CoK5xzwW2GSQ26fRuguW3EPgCiNdYlu38
+        U0uD3UNBe+Bby+FQkvoNcP6TSvepym/e/Zny5/4Bon7OpR1WIbrer1pQ96Z0
+        y6eGvJluuZbuSG/ylBKqjj61Lauxb459SuYqruYbZd+talh0E22DeuP0YDtM
+        sIZnDs6vqBvYsfmDTGYDklSfBR8HnEf/MPZKE6JbJ2jJVik4UkLSNphKVdHA
+        0KHRfQVU7gCTqaA3ZGPq1dj1FtUHCII1VxRzjRnDb0BmDAXX3Qcvf9Z1t0YS
+        XyF1O60NIW+kPlT34O4xxmYS6g+Q0SdtjXGnP/7QplrjLAmLgV3UnFVqueSy
+        7OdzycNIenghvBIrppZPiQPrlvafERes7tNbcsF67LyzjfboWomxpdrKYDhM
+        v9CnksRLcmvq8WpR04MAzVgP1JUD6jFMJ2v1KeeZ+/KmWt3YF5muZGJrrza3
+        z4f28QaqlxZr31UvkJcOMZQi0HvM1l7qA4WZEQQVq9/0XOXttVyCnVqhj0de
+        C4rQYbyaQoGRJInGmT3OJL2RlDbKlg2XNm4k2K51O4o+qwKxjl93XMatfWn9
+        w1V45bz/Qj2gL2eWhFj+zVyF5cQZVt+k0131RRBei9XAzHFSFOQOZCtoutdT
+        78OAidm7srQywpv5hE2f6OVDsub2UzBz0bhhM2OalrcioxBdTtQKWexn3pO4
+        G7wJm6VtqFyzPI7+oJkMXg7KZy8yp6iNxA3ijlpGvDD+PdKJRKFsvTg9Y3Z5
+        NZvXkwRARknwcoF+g7H8DcoybHP+s97GIIrGv2Ss9w/Gig/rhzece04UBcc1
+        jTooQrWDWaMNnKDb+NwG46k/p4vwrux4Vk5ewg/pzS5dlr2AsgY1VvAfBaCn
+        VoywkDnzXI4pHLd1HbEmS4p4OxTEAUezYm/AT+qDFSrURZuVLJQWhyFDgi9d
+        D2tODUwE0tzXfF1RIsf7EplrtW23mtJarx+mOntXAR/QeEuKZ5TRYx5U4Q1a
+        BLkG3vB6Jcg9k8ytXTnHIAgnx6wDUXTTjhD3OaAmQDu6oD1UOg1qFlV5zBzH
+        TPAoWVdown7GzIZZltNg6SvIlZOL8dQ/RUezNEGTNdvIu1WVK5s+sWe3LIV4
+        MSD2ZtesPkAORHd972n7Hjr2VSLjYYGn1oQEvE0Uti8VDbePZWS435hzPMt9
+        4+f2FxoBouGvJt0f5u1HmS8pJmLNCoBDIo7cUVS9wFvBEjz1LmpXbAEhhnFY
+        XEWDFh6LcD1B8iBAfbaP405sJ4VTqOqxKrHIQkvjh8hdiW/VBjLZFFP9kJzo
+        nAFaTrDepzsYUbV6NkDMUc8IV6hecnWM+apFr2K+I2e/hcs8+GfLM2zEP3ZX
+        aJ9TglYrhdL5p4q07ORel1lhQp/tRIDNZz9B8IDtowrK+KsIgK0V7R0K5/j5
+        fnFmnFlFFJFCRNBz8vpUUjON+wxxcJcBggIeHobm5VWpjtkFVNK3PQNfYcJe
+        88CT4HR98oZ/Rh38Wxld6au2b5cx7b9xad6U37ihX9O2/5UxQn1VLSV0jejP
+        pmwX/g7sTXQDThXCGxkGo14cjH37zqANTQNYQIjM3tB+0qLht7IwKp9bnDhh
+        zeI5PbpIlITjmJCPHQind4oMjqUkxxIUAhETdQ3uWM/Ic6ojPeD3U/X7J0Ki
+        Q/7ZOvJh8+K05x1w7BQUvI8A22VEre94PT25XHsEYtYn69nameToskrGAPHm
+        QmM7Jz737C7TrxgUsUT37GKx9CcR0h+SCHWt2abStuP0qGFcUEhpN7NJjiT7
+        jQoeuLCQgcRQtgokcoe10KsamZYhHwEzb3u/q84prdJG8zRQfW7KK9B+SBGA
+        4NKG/YbV/mEena3cfqqc8P39e+bRgV6RoScKm4lLor2gxjpuV/TRvOzaddRh
+        KIdOFuD6tHUAO0ltQToCcQ8Ffh9ubjWwMJP43gIeNwweTMQus8RhRYL9aWRu
+        majgIb5j33StHcNU3n9ZJhasmWj5LDhDgFUqlTona46zTpOr10VR+tCf/ar/
+        jnmMmW+/PlpgGCG/Hi0XdLOY5akuetrgoJe3LDSyNmqaq3jYm8vVO9PPhAXL
+        j7YF+QXxAzVNBbB8x6hd1qwph+qBiiU7HJN7jxa+0XFT/7CECPeNERjs6hxX
+        Ca+IHusOwRopW9bEmWGUeEfU/jQ9Q3jrIM1szZKM6ZQYwYLfKi7C0JS8R/N4
+        mfTqQZokf8r12MniHi9SdvHq4OIBMSSxzrKeuRVF5HCFCZpvIjGhRgT3Dy4t
+        L33PB3lAIbCfyNaNDrXqNoOhkOjQSnoLt3k/Zw59IpdqBu3V1y9mpK0F68TO
+        ZBpvvITJGfokIKbKk4WMSXGS84g6rdZ30VNKKnRnnpxkQQ3gAYMKPoHqBK9u
+        85gAI7RRjJfhx2CJx2+Mkh92qivXn48RBP1vV1mCwjIC+FH7H6mS5Hu8llpf
+        zC/jKdkPwdbRsOLu4TdNG8HuXn9xfuWmfrgd48R36rxqPqwGqTsdfOwEe/U+
+        xTHg1oefErEUPPoiJtSuiSMTxLTSSeblhU6V6TxwVc4NEk+fdVta+P58ts6x
+        oT0LFYYANwCwVTrS5vOIkD+O+ouQbBlfjt1wve8P/BwY9Ku4fRvNxSF5hTkF
+        kAruuM3hHlC9WFg7gvb25Zk0D+0TjEfuMbyIvvgQFTm4iny5XZpuWumHbCSQ
+        TjhP3EMK/Ce9Miwix1V46bkgu60e+7jHSX2HrnTOeZsVlzBlQQl4PhegZ18P
+        EvcS8jMqJCCHhjMq3dONYe/gqCXhXvil1R4YZ5/5pEKlXqjzYH5jxhnl+/7x
+        N3sYul/cRePIf7OL3o75z4RUKvgN1AlpIj+Y7DI+zBMW3NqDJPeHK9/pwpJp
+        lrOG3vfivP84yciKWkSkh9cHDzag8NuB4KHyYQ+RKeBmCMfZnA16UeiWUwzO
+        Q8TDy8yw4bxrIwVSrkK5vTo2U1izbS3kqXoArNQnIIlC7xTAK2WW7oXYCdf6
+        U0p9bOpjaY9s7aRFWe2kcPlFPUKRBMFEfKeQPZExTIEzjOvE0WDIqQMffVng
+        kQJtCSODw0ZX6cWIcYX68YkRbFy8qt8yF3J6vLYunb9FbVeI3fWNqX+BpjBE
+        fIW+hvh+AAgGy0ngMY/vEDhMwJRxbspKs8EmKXxJ1GJI6WNQqr3KIjEJ/Eqp
+        XZN+P8C+j/1Uw5Z1YFl0yxgUa/pg7ioPLqVZYucrk5gqSQdN90cpJR5pxB2Q
+        k8Be8tgcgKhBdEb9nj+z8HNh+vwaHcB0mmziRr/Btbxry5IQm2n6cKuSO58H
+        774vIZ0locbRYggppBMQX41LxChczrLCG+Syax4XPA5qnpWGmr41vJlpYV3s
+        97CVixdhmmCClKKchHf4YU5xNTwXoORXiLyEGg0CgGQoaASO5xmrn0YYK8xq
+        iwjS+mmNLR6i+ukadmANTBM98BGQkBe8cpCbsg21VVfI26bo5gYo9vOzGStN
+        NJs6pPwNmwQ9eYPADhLOWhzaK8cO4++V/8tXTUN9FdL+f9n+HyjbrzSsP6f9
+        kuZ/XLAaaZ/Wv7K9+HKHK8d/7N0cphYhbQlg1OJQjdPncdBbzhoNU64tLWhw
+        i7iPemg/JHJCW4ZQF/hjF32pmcPnyRSCvd/2tIlTCKNi6HKMitVMsjTth3tr
+        V8fkI1DIWdA2ybOUpxZb7Dw8kxhs1qQ1btmJRekq0taPO+1aDryU6YhMdpIZ
+        NSRguU3mKAgEK0OXc+w9FcZvOM1/yNov7nmQL5Gy4CiI9uy2moAG6Ta3Xbcm
+        G085X4cFllA5soIhbOOoZfW+dzUR0kEAwiPhuY0I4jwXHl3OIkGtlerRGOpT
+        KoLjByvieC4CXdPSBm+HzRXzGYI3ANfqgPB2cil01e4tAVRKaXUjyIMXc/sF
+        pppZvoFoZjjwdklluD6ORM5dGb8QHlj3rOwn01Mf4eZvh5emLqe6Fn3bJBTO
+        9oxgDN+XdH9vdZ+IXhbTcA36+jC8PkSrFiv0llo4BLMV4pZpc6PtVudZFXeS
+        6DkSM926D90CbDEq8pwRfITyk5pv1djeKrvcM+4RrBOGSrvxGABBSxE7FUPJ
+        ya1oi3aPSKyo8AqIGfaI8B6qvWgUo9maIXMECkVpk5vKIHYskazLKae3f4cD
+        jLVOuvLTrLIhaN9JXebaj39pT/L1XocHRXem3N5TUu6hwQ9eLA64FsLSa5Km
+        WnAeWmv0o8YP0EFqI1IQWNnQLha+MJVIgPvDezJXMW1slf1uYIey5EIbH+Hj
+        OPDinMqnpk3K9UTT5+T2QJCLz2yQ8u0aHbJU0TP++FWiDTXMlJ3GDpHtSXal
+        JEpHMI9rEZf5hVLYqJMhrc8KWhNqwYGw450RXqFDYT5M84WxbT7g6wuIgh2E
+        SK6l29TgEX/2LUqkWP229R0TYWs07/LKfWQTnGlAQ6+RtxG13TUoTBwPBUc2
+        83dLR9Sq6cnTLa7imW61Ie6HUeVvCFEoaYdRINDA6Tny1sYfsW1+2Ggw3Ogd
+        Q4P50texLw9ML9EXKmtJP6jgIoeFZdXKmI3k64nYD7uGQDdGkHOwILxiuzNO
+        nksAqoh+ytE2MRwrzJtsYYKhxqOipndSwVwNRE2fKbQQBmKz39FR/MiKlEA8
+        d/yqh/7nCuTnYZH+MlmgfyaLH2laX1+k0xE1QfTiyZsFo6WecnVj5W8DwE0T
+        yALVUpsnU15tiFXQmS7anXZrGOl8mFugp1+bW12Xu/mMYEebGjmal5w9C7wA
+        gtVY4+fmV48ExV8QgoVY/8lzVaDhpgG6yWh9DL2NZ6moHFkGsuRAY8bR1Jbb
+        Y6RPKCX8hr55a7qWXbkst8Ity4+hIKjsz1MG/fUVrGX8cRFzivOpQMDhJNyJ
+        pnD2/uO+avn7fRVu4bAiWrLeARR4xWfx99cE+AsmVw1TqINAYF9kl6CPW2NT
+        +U47ci0Jx1RJH+4KWRoDFTMkHti1+jGmcAGI4giU594TU/Fkm05uh6/SClos
+        lUQgeF1qVerJxEMkVicd+akx7d2pebV/nhy0VTsRx78eyf7z7soayzld/7gH
+        uJa1fP88dUBfsUtGHCfaf6w/RRCaXSsDaphUeR6xeJpPNONBpNL7GDVZTTi7
+        31/0uM1SPN/YAXS/2u9WdqWgS8Yu7dwJ4RYVZ0dKtAT2wr3FKx6HWUAWPyn8
+        VaeG7qbSqy6qDLGdnF5Gn38jHSuA0VzcEaVFkVdgfjYei2b6faDmZWmxhL8k
+        gRoLTH+9E5J2xhGq91gG9VNL+Om990MUnKsdGarNpQNuY+uKsee1e5/GDGv2
+        WOPIjmmWOZc3HyTXjaUjK84H7OxnNY0dUm35vsGnd8JAtefzpOotuYkA4KiV
+        0UrMfPxOKvHuknTl+qtsxr8qivS/sBn+J5vN/5PN5yHao2qSJIiZiGJj9Ruo
+        kTeZ1L4rveXomMHH368Vj6VwJRDwhlVz/JhDtu5wdBFNAAUenL6SJ5rUSdsG
+        hEJf4IiQoMW6SwXzEq0FiSDHHRioUEUdi7OqTp743muxQQxj4sMI5lj+jcXC
+        j9avtu73Ov/L4HZbweMPrGoJE/Ox3w3BdnAE0ciVw3yhCLT2SNoz2OfNT6X+
+        CMgLSDeMqQQZCfz4yhwxxYYje7Mz4d7gfhzTUmlI0FHcuKCJLQIlpautlrSq
+        z49s74ZUna6wUSqSohMUkSqqh6aP+2hj4sDkK8mJA1+90PJ0HALh4wbdkFX9
+        CkQpOOaPj1Igw6vzWDzDX8fsz4u/8s/bjl9EjPrqNeLt+ZY/2SXchn/4NMVL
+        t1DHmao3i90NowirBL823pNBuVko0R8KEsKIrK5anlTeSIhNcDSEjRTIaKz6
+        AneN7RLB2PGxJqsbu9F1O52BrPfjnjtEFSnzaYmIGG0mVMKflMU3BSTVAPaK
+        1v7Mj/HZDkMM+7miUIt1tzqaYc0jnDneFEJOIsH9KXPxkwB93f11xH59dwVD
+        0FfmWUPcf/QhSSi4Sj3zMdoyf4r4PHDvPoyelyb8iBmwQzCNg2/NC+0rqKce
+        PsAOjqhFVDp5M5ewE1c5RvnwWXm1HrMwRsKPe1c/09jThSWpSlOSWeMeaUz5
+        I91i27eOn6v0CQ1YUZSLFTnYnGSujcMrq+1Rh2rNM5p9uKqGbX9zZMqTqR+r
+        wXuXenXnmIjqNRC289QGvPvnOXU1KpDLQG8WVSDa1z5ojLZgyIaeAIOE63zW
+        PFP/cg//3stY6Mv8LsPuf3kW0LIZh/oKpHHMcgYFq3Rna0wvJzRZ3rDBeOlU
+        oH56vuUVnnkUpiOfQtEJJ/WAWGrTFpVkzhkPAvZ4pRRbNA7RmjBdlXhQwk4r
+        1++HLBrrogCCn1WhISt9ZiwIcKAblUhbt25Fwa/q3fNy43Cv6S73mLf0knDW
+        ghKVTLxEzEfgKLv8vGFMBFwXDsed8vIHDBi9GDW3D04EGKJzDdkjAyyAOyag
+        ATffRyIoXHICELGGUdxWfokjGfjAKJJRTVsDYXNrLxBvWVkRA0zMlSkdGLa9
+        0+Vl+ty8ZNWOcfmK0GxZ/988nfpzVfnzty7kl++m0DtzD7zh3Jlb37BP3b/Z
+        Dgq4Eaa5x7tgG8U8R8c66ItmX0p8Z25/RhtmeJbesp1o5xIQR91e1CJDra4R
+        slEPOXacvRrOOVdC1zUQCHjVbr7fp8p7D+3ypajxFjd2jHraqBw/XXPNh4Xt
+        rqYptZsd7+awV2YVQYPl7CiX2TD0Ihsk8LOkUH6wj/qfy9x/+5/ldxXiDC4A
+        AA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,restypes:.*\\|Platform_Operating\\
+        System\\|.*"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '134'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1207'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE1Ux8rcaAB7l7nOEvcWyMG9zLi3sUNY3O1xt79xC9ln3/+y
+        sEJHgYQQ+vn71uS377dm2IoBjMv5jS5gJCMKpKCQ5NvybeoSUI5L/w9kWqLD
+        eqoh/+1GrifqP/6v/NuciiUBzVC55wqK/vbXLU9Acvv+8/cNNH2xgqSfbt8R
+        nKEJBIMxisbIv25b0n2KL3cFX1X2P5hI8gqhROc85oHI7Tb4DzfhWN+hSbcp
+        Wt3ha+EI+FNEdPlEj/alRL7xohnQGq3uiqwM84vF8WQFfayyhDFzi4guRGHH
+        bpp10Efdvma/qEoLnmGmj6zQ5zWmemuTvcU2sHexlDmVrkcvyVYjTafwSFOD
+        itiXKzbFulA++S4YsEDbeBgcabxmA/FxUULcg5PiOPgKdS27No9o/jZmxY7D
+        yMme/VtIzd0h6IMkGsrhY7QjYemoSQFjFbgOOi8xYQmyBmBG7Dgiiw9abVw8
+        XZGhmYDZ6Qros7iHKiWNssrdAe/2h7d9SGhayzLZpnw7mIsRpQc3kAtB0k2n
+        Pp0oyisRxnu/RqhGTeEmR6aS9Y80K8KeXkK2wpZQqNC1MNiWGSPDkaWYHbO7
+        MxHv2hqYAgN0V6mCQ7hbqVdQ5rF80+VKXnlzJgsZMxGRxlwERC+rc95zAXQV
+        zex1cNSZQYsZVK6i/Yy6j8OFio8iePTV+pYZGI3WbbJhIZY9uCR7NHi0HsOD
+        l+ao4mVJh3gj4vaJ3QqUPUOhe6kjk5t3PWvAqKjiIBcmXvJdLq0yDqtm6Fyo
+        zoZmrJ6cHEufTdCt049jQRB2BFw1nYdfa7JonZWsjVOGsHgbQ/Fmsb2IlH7v
+        zd3oIS8gvoauURp95RWTDcA4lRcKnHnLy/SY7DgHPazN3Qeh6UH6QBsfy+wK
+        Pad7lWIVxaXptdSmM+KuY/F2i/cCGZYjtQ9Xdsm1vcM2Wud41ge7D2IkvgTR
+        MBkE3UIxogrCiEJ/eKuD/7y7mNGQjCKKpNM3qotmWrZW2JqctjPkFZzgdM4Z
+        1zW6F60E/qcTvTwxi76n/BUlUBU+noiKoMmyONeyxG+PZXyvJOeikyFkJmXb
+        fak7IqbeknqPXoOz+s68K0zmYYFIU09FbXuzCqr3JlkyKlWcu4kPsoHIpeAT
+        nOc8+c1THoPApYNm+qLtPVXEVLjUcEHgXknnIyBRw6Zjwb4ugYhbNtvsPSeV
+        IMtbm9LZABWHicaIyZDbhoeoTtdD48SCUlvCruBJuEDEuwRNeT8KkYE/sViI
+        t3RSjw2K2H77PD27wUDXsXxa2ilPLCEmPKzRfD+hWNmbDkw1xYRyXfd9ZqOe
+        ZqG5w3NL82aAq1NhG6OM1dnJGWqPmsB32L0fBQ7KgiwChVS2l1EqsJwU7eee
+        qR1UROPTD0WU9gTWKTcxMav2Slk0zlwtLtWAOdUX721LbfGvq8Xu4ehr3BVo
+        XLmh3LBBFSBezQV48eueSl80wSeIT1q/C6vYPyvXAXi3IrhHn2pFtK5eMgiV
+        zMlCX3jj77TTp4l1Ph3BeaSbemnMh65d7ArdctMO7sE89p5hkXkn1uCz0eTj
+        QvxX3iEAqdl33G1ZCWZEfwj49PWsP25/fv359S9cKb7s8wUAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,restypes:.*\\|WildFly\\
+        Server\\|.*"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '136'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/metrics/strings/tags/module:inventory,feed:*
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '89'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKtWSktNTVGyilaySDUwTDZNNUw1N0xU0lHKTSwuSS3SC83L
+        S8xNTVFwyc9NzMxTigVK5KeU5qSCdGTmlaXmleQXVSrF1gIAlG4OQUgAAAA=
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,restypes:.*\\|Domain\\
+        Host\\|.*"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '120'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,restypes:.*\\|Domain\\
+        Host\\|.*"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '133'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,restypes:.*\\|Domain\\
+        Server\\ Group\\|.*"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '143'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,restypes:.*\\|Domain\\
+        WildFly\\ Server\\|.*"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:31 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,id:Local~~"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,mtypes:.*\\|Server\\
+        Availability~Server\\ Availability\\|.*"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '148'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:mt,id:Server%20Availability~Server%20Availability"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '135'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '348'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAG2Ny3KCMAAAf6WTq46CgARvPHwgUKGCIo6HILECQSTGKDr2
+        2+ult+5x97DbJ8gzMAL5ieMTq2nbg1gQ9woWsSqiXsV6S0w5ph86RzlBaU5y
+        1v7840AXZIghMNo+AcsrfGGoOoORKGtQESVB0hRJ7AKOyBW/dzP5Yut/TMXg
+        hqgZ6A9IosPCDwqMG15vogk0ZP69z4RpPDBTN5yk7sTpS8my6XhGWE2D1oPl
+        Zz5jZRi6l1XsBq5eECsOazp2XOcYNuZXGGA/Duncj+plcbxnxka34qnk+IJj
+        aSu1PQ3HQryUD0OSPNzLut92Nt4i0pLWfggasRqi1bAtGS1UaT14lyxdD5Ph
+        40r7jhxF9g2Ru62u+Kwd72lZx+dsdYRn1ihxeuW1PT+qHcdCpj+pPr0Oz6/e
+        mJL5vXAtBcOsPMykKJnDxNADXQev3Wv3C05zf2GQAQAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,mtypes:.*\\|Server\\
+        Availability~Server\\ Availability\\|.*"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '161'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12528'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ax7LrzHKlX6Xjn0IheHdn8N4RnooewHvvqZCevXGuokOa
+        6Pa0B9oT7gDAYlVWVq5vkfkv//pXk//1t7+a8SzGfVqffx6SbS/Wf/bHMRmK
+        /H/x05A04z+v/6xPWdL/+7//9U9/5cme/PW3f/nXv/ZmKLY9Gea//gZjNIXD
+        KEGSBIL8019n0h/FO6yMbQrzf/8sOE9gOz32FNBw0qA0aPaN+UjizNYSmRmn
+        r+vsQJHjrSVvWXibbgSzefKbyQfBqONsd0s2ikeUcjqJuy6ETnt7nN2F9gQE
+        YwO45e95GEAbQShk/5hPCqMgmFLzPQInkDW/q8/4Miho2QsCaLR+cjA8tm/i
+        lliWMAnxLBIBwGdazpFqlfO7dH5hyxkV/fo7NWnYYy38aaCd+kBRxugg2sob
+        ALJziFobIOY+6iAH6K/wDNbiAZLkUq7rB+EW8iDzAjrh0nIBUFq85HTzAN35
+        G1bMgi5hFDeSzFfd7wWAvrol84E1w1UVOxDlZEoH4WqQd0hR39Yf+NAItPVD
+        78/jfYkzjn6NGqj12cUBBdNcuCM59E6YLtVj/zjjqukpDID2hJ9duh5hCySu
+        0SlBwIC0nJxaweJTGIr1IpNgRQrOl13IRcKI/BLNImZFbuWEFUNsnIQMPPss
+        Xm/jn44Nx3FGHPxWb1NTWuns77iwIpuYBxKH8kGKQ6ylwWh1JdLr3S/Z6qGa
+        1jEuepE7lGi7uB9GT/aP8lWV4Jxt0mKy3P0IspTMmb9qdOFkKKeK4lXnkV7T
+        RR/jOfxD++9aGBHXiLSKocyzzIXe+1VxKhNmoP4nWSzkhtsb1q6xCpER4SIX
+        CM3IvUOuJcLPGNpcIATnQZ1wq2t5i1Lp4SFmVgAGQNgXDFits4Zh5S0Dm6qI
+        Fqk+gcSZM7iemohic7IY7SF8Sc+Wdxm1ftGfni1Rbja8jtnBVTqBSgRihKYM
+        sgGsD9rk2Oca094yDOM7MyMtaDQ5nEljXjX1oST7aLGj4qmKs5OItzdfvhz6
+        hhzRcDZtS289CHxefvZe9sPqhwmLIfpxNF2y/CNN6IrkEdEusRn5MZyJTwhX
+        u9I6NUxbcohieMwcGduFHEvviyFoEKZPR8IfOAhXqnu0jXGiOCWbGdaymCjA
+        nhw0g9iQ+OL3kkHauGSCtwo37djggSSHyO/OfDDNMJssPmUORYWTDo2ja934
+        MMpJNVJ7SHJXiDutr8m2aVSZUsImKOqiq8cg9qMTdg92dLh6OUiHgx70Q3mW
+        VFyqZ0O/Vmv3dKjHgE0gsCAYD4MRuz4qspV7Nl3Zln8jwIe/rjgpDeDNAj/3
+        rFd8WkKmpEYi468Zh9rs+vX3duxu8vqUl7LJ63DzisVlFbygdr7DzAlJ0LFr
+        QrGaYg4IQzFKsG9pVFUY8pifN+E9u3gMdUCO2bnOb9I6kf8mUlwIFPb7TQOJ
+        aCc9piqKoggGttCOrKbHO9l8f1OM0LX0+zPzWIDXlclrYoQrTV2GTJ9I4I0O
+        XM0rfEE+NTRCP0ifO3mobxEtHfKpGogG7fAL08lyl8OU5YoyCk/SBXrj8vpj
+        f3j107uJKxSRHdeUMBK/PeO6qK4hbQ6DFrLoX8PBgOMWrIbr5YSYIKFospVo
+        LpS3Gguq34968LjJfznlrYSEeRS6a2Rjh1ATUISYL7bG2n9Dy3l+WVArmNEn
+        V9pq4pxYjmtmN79Q2Q1de2eq+17+CsdLYDZIFF8dYOgt4Wt6MgaZyRtW04pv
+        MKAqGGj4JmIx0X5LxO2Z8DqXdvRQa1sXXo4bsdpX2KgB5UyD1Jr4nOAuUzWw
+        37rkFrbhYjWkmDY1+P5YWb0/g5sp7/Z81mYrqlaeKX7/sWhvJagH9cvCLCJR
+        qpkzZUwgVvrTFO91Y3K+xS0/up3jyKicq9ja6d0i0WRURlTskvFLXLj9HfO5
+        Ww6CuPbGsITZ+wzJp6l1XA9tOOmeOcT4LQO7Gg0p8vVVVLicFppfEmrXCqZ9
+        U7FDWim4UFTOOk2A0jnRBxDPZRT7UuWOpuIalk0dn71poRs5LAEXwLCTb3GU
+        DOmiLTHP9vczk1GLEj+APOQd0Obv3juEDRsMC7kWGVTD98tFgyb/DCq6Nycc
+        NMWiEuUKoS28IQnhcxXbVbOylqFjywj8kI3Pqhi+G+TgL7Ajkgw0HwJtwPHp
+        3VClR9xdPnLotxp8mJdX+qTwVqGswqnrDHMdEn2SAFAVE1yfWhRwObBCxX6y
+        pICpVy7VTKR4Ub6xJVh7R0svsK79S6K/LnYm4KWFPam2v/72r39l9TF2739/
+        4e/Frfn9wQMCQ6C//u3f/um/RQn4P1EClO2HKG2MVsGaSEoWvEGUxi3/h5fg
+        aJMjdqQYBvAewLogaTrDgE/CXrJJBXOAZ1oHZQKgLOZjWrYe2fqyWiKsqS+n
+        j0i2Fk/1YzqlgvwEsnQCjyozSAK4wE2hYDo+b/kZmtFRRLTDSz9YRq0qim78
+        DImJUHgL/CDm2y5WNx528apnKSw1eIJXCkI7VN4PqVSny1Rm9L3PwhOgPFx3
+        ZQblxoIDtR3uozx6NUQzGBtpPp3ke/MazJaX+CftIK7G3z4wj8yXitPlZuuA
+        YSnwz13cM4HPFlvCvvsxkWkD4DdXBO78OFlpt/LINuzizr4P4JJI5+4ir2xJ
+        jPfkGTpPLHMV3FnOieTRcRpMm0JQfyFFP5JMOANZlC4mZEEyxVIYE3XuyYqJ
+        SmG4mH2ihY1nOabfBhumuaKw/Ca5dm1MbYOHqeXUcjCHOegPIn7PkqXOCWRu
+        t8IAadSJ0a53MQZ8ze2DI/ud4Rp7nnQifS7MvzG8hes4OCdmIxLmG0SEW+i3
+        SdsOUcCYAa5zre6umXaoj1n4kKbAs4J6DrFyIzRmq94jDV6teUSacGwbXaKK
+        f6hs3oRaDk6hnIoh473gqnyoiioPI42PGaD9xNzmGSlO77EsocWQG4tZAcP9
+        TKY7jbu+aer8DMSrx9uBMPYVNTyswFyv/A1Md8VLUTE+FDfixnWCDwsmhKT4
+        AqUoHOweEcIzQYqn37v9V1xiILit77Qu+aQE76ZgFRK9xdj/BRpXrNIQOWnI
+        qlv+m6Fn4KvDcnfYuEtvLiKMkCSim53GGPqrGk25rvxBiKTjyaYO85rbaI7f
+        EPbTTwE3qc3HaZhAfDddv2c6HeuVF1GThcEcgabRQ/f4Xo19V4A2/8nIn9dp
+        kWH/skKh7FbDmXZUHlNgYQ7cwK70DhUkXHQXEv8FI8N58lSVI047n56BT7xm
+        grlmxsTrrNXBRQhcM2hTVc51Z3TzivGmvmF3vho0d2rpU9/couekH42W//Do
+        dpLlWcjkTOhCpCMnfGDOChqKvUyFPxViQ31QtHH4/mffOd6QAIftwPdH7kR1
+        ZfT8oAPaATmj1TC51jONMvvUOTo6R+tiyEMNBnIAreBH0tvRVDc7cVBsRL4d
+        DYJFCoO7mJrZo34LOGiWAI0/BzB9V81M9kwqBESgIrzkoaS0VpMjCzW6d8xA
+        vHUr+Ch6qFN/SDsTyG8IYvaOIw6lEegJ5g8IRMXzJvz6XbY5yiWs2ekbXjG6
+        OMXOvomJhnL5c8+ga0BQeZxd+Y1AoHYsYCoXpVxC1EVpND3JQFrPHgiukdBa
+        0J/Vt0YlABGy574WiKe1n187UHQUECWfnydHzdw4HVbWHJ186GKKVAc2dJkf
+        XDWuBXt8mMFcvfKxtQr/YhdacY5SuN1thY5Uv9clSLFq/d7qu/tz3UmdGn8c
+        0+HkARfHy6FGxWQ5uVND+n3A64me5R5jSziicqhVa5ZOVh6IEE7pkd33vUfe
+        Cc7W6mvLqIoLkFfjCqd5X0wjd3N2Zc5W61r8Z8CSk2LO6UHtYRrh/IaO6PSY
+        NjsiF3Wz9meyopLRL3L7P4d7x7/KrHrX5MzE++5ZuA2H6pWYZvnHbxlWsFWX
+        rZQK13yGfh/4ZjvmULXOle+RVfOHcoRax/wP8w5F4ORZ429MJpfSLcp+3/sU
+        kFp817BCHuF86En7EytlY74mjLxzLSru5h9hdRinxw/JBs3legfSLpuPXSpi
+        tqtht169BEeHJk1qWKtnvMlBr8l3PpDx4D5Cx2mt/zqm4WJ9VDzGTYxAdhnN
+        NT4cwrsNlzQD8TUpOjZr/dnqChHOF/5G5Y3RDdXsO4ln28w/8XjdynvPjaQ/
+        e/yB+j9r11vsXXv0KjmvPPeXj1YVS8HgfdVH5ykc3plxKVtz/92b1yTPKezR
+        6QqAIPwlERQw6TUCumjGYLFEwV2x+J2YAKiQUcEs7hp6iEqmO3MAigl0NQgc
+        45Rwb4ll3buo4L6PGnfN3KwkYtwPkfdgfIxkq1ZmfFCvRXUppBNVlGZv/1iC
+        2iQR/YWI8QB57j17BL72r2dRjqQQ2VZkesHX5NCGrL/+ASZA/4kJwLjJAHrS
+        MP2q3Qg8K4nO52960Za2IVP+DJRFzmYhyKmIi1/kTnsbMpg9FeRwNc+fjohg
+        l7PSGmi1HDs1VTMbiBvWZ6k+SLfu+yCaAsDoxUgsupFl4l6LSFW9z7AFe44w
+        lmFRkosubcOiCeepy17ts0iFln42NoyfBH/UXWFB28CH36x99tQKEV/Hgnyu
+        DJypYDEQOvcrNdlbrIzTwcDaA09HAW+nQIaHAQysHBMecF7rFptTh4jya+f3
+        fBySXmxa0fR54oJq0TveUp6ECodpH6fmtSJosdF3Qjn65N92AgnrVKnsUESF
+        BmX+C2FVgqLbQ1UTLn/p5wJfyYloqe8H/jbFnZwgaLIQ88SyL14Zk6j4jeKG
+        aNE6s2x1ipmmcn5FutpRx3SFHnZzUf/KIev8qCqw+rj8LmGOf77jvnfwrRLr
+        jdNQPSVi8KlXUpSIVG7G5JRIpz3Yi4vlKrDLiGKqx/E1HFaV6mvJF6jgDa7H
+        RP3AsXsT3c5OkkFwa1c/VeYqt4hXBfAu8utsiahjuCQ9JDoOcftVuZCFuMTw
+        P+07mYTrTx2DY+x81PwzNAO0nyQa1QiI0OP8fZPsoN4iqjjd99cpi0ghwD4w
+        kFdHSTgtepQ2foRpfW79EBL8aKxlPpcs9G01NNkuZATrE4ZLQLvjtVm5nDsC
+        rO1uCN7RKevu2mE67HM0iGV9NVpVmv1ivjHQ8mxaPKPf9RQAgysTyxU9e5Ts
+        3gj7FXzSOw0jnRWDSllMLUCLl5yfmsWhfeLiZDzsakQ+j+8sl23f5HlMMmI3
+        dgt2e8zjqdhWJ+5dMlHNW4mAXwEBFVmT/J92+Z5w8+6T9KDxzQZqIZ/hW5lo
+        xsWf3anfMzgMMIMwdobzf175jGLeVxtNQRMCEXtdbzMuSXuH052y4WZAChXi
+        xKavulA3P/ESBk+zWM+Ovrb3G6lOT5TTswoIk4P6sHYPE4OqtEIH44HasEIL
+        cyB2hH5QFiKldpzICjdrWIXKKwWeo3wszBzTfP9I1CuOI+xUVhscpO9wQKuz
+        5mbGiFPuR6uOa6Oth0jd9MLvKYtaKYsdtkS2WKi+uK0Ufnm/BX4ewu+GckjI
+        3cnXXznGjcr77I1vqKVgbS3nkZtKOYU1rRv17FIUkvS1EyGEi6zrTASRsUQk
+        Rva9C3wLTtvK8JCYMGCUwuAjWwmNuCrZfr/eRBM/ej1BLdASam8bWpJRZTRq
+        28RoF3VR66+rgOFqC/22oJlPvjyA9RwDfISI/Hz0NzS1J8KZRki2QNXJ/ugk
+        jNtsrn5nz0ZL+wpJSg+hENDsLW7eor4cBf390jhOf8UY9Tb5+rG+D3cSuKFH
+        8YIxlkVnO8GhLuDuBLOOJVj2p1Qv/hwDnrIB2bntkjjDn+DxRpz0XCiqkd4G
+        zZ654rFXrtOsx8KNH65SxylaR7bQIzYJM1r2Zpf5KbctreAUlQ4ZFpFRlyNY
+        5+ccjBQjLgT9gfR4XG4n0OD9s/exEF7Ds+/MstbEDgo1zaTi8+uPfSFCSQNO
+        qZnvQOvfck9uxMK4aaYsRt1PoZJ47JQAMxOey7SlBZ3t6u5d6chrq6iNmC48
+        I9eJ2NOdduMMvAbCpCkmAMs1zo0l16YjHVobsJLZuEKqwFxTukI3sM8EVrFy
+        FNhRHN9heXmurvBW9U/RQjR1XyNePW6oBKaC+z93wYhAjQR/XYWa6D+7sA4z
+        ZYdHNUpUAEMePr828QgFePtBXwcvXt2g+CQg+XNYMOBkAyW20PrrJZxqNKXD
+        OhvbboMKY0re1MLG/jZMFTEldrmuFG2h8fiqharq835+E2A6DmwmAsEBAC8C
+        nPzohABEU2TuZDf9DQ0PeoVg8ZcTYIF/h3CG8nNZrzEkh84M+gHvf0GGE/Oa
+        I3t0rJN6a/KzTLH96tz6O5ksWegFt7k57Hg++H0mabnx1ZXg2OsXXit/aN6v
+        9lqGjVloqrRv7qsM7ilQDXNza57Iw97Jyw+aM2IBtnV+Vh0swD7nmeWCx1Hy
+        Na9A1GAvflJIlUKHBqWn5QVmGCSdmqE1W0+gr92IyJGtaxnKj3jeI4WPDwWu
+        yn6iTDCvvcZX/weYANP/iQkuWCZ1TVu9Jq6P7jJjFHJFzoxhD4zCrIQnrvZ4
+        tKi9FKV321lEW/Q//PkZHXfUPlrXxXmqd14+aRLoKLekUfWDg68VSIimcVWs
+        YYMPKbWYWhNtCUbbumG1GWmT2s7Vhb6+E/6rkpCaDTAiSkCKbEiBkKoEQqq5
+        lGWCoSEtNjTBA5l1ut2erjOfQgspAagz0OoELcJPIBvhNR9Ub7sAiI6fDedP
+        aZ/Nu6cAKieAnBZo8p06VcFmzwo70SJjV5W+HetDO8uj/wUbdpFQdKKOcQHK
+        /MLAnr2bKwP2j0HWlNxD1P0gPEn1ibMCVXCw4IMg3ey2ZPzTbwne292UBmiO
+        U3KZwyAndTqRHornFAJtUG6IHs4gOhfrPY82ChJCVzjt89h/65uoMhlwXddo
+        ySUhY3EJHqpMIQL/e7bJc2zdlFDqLQ2FFVMJYcEqqCGlEiCY8So/inbLmEbt
+        mnF+7QyYm8tyz5rUC9h1na2UaIcfxf9+hdEJmUi0FKthX+EHB0o95gZ2n52t
+        VtvfP958V08ubWawlCN6N1qgutvPzS7uM5O15R905ITDnhjOtexc0nvUvl/D
+        CVW6M520Gca5564poz/3kdr15WmUo/6qbjtWjUrVe85QLaAFT6FMI0Jbk/BS
+        kSszQYh/3XS7ndj47WAoNdoVkR860BfxCVXFdHidSSdJ79N84nAzr2w0f0R+
+        2M2apUS1gCNHw0LXoedYzoh6thp8bgSdIxkTtThwJCJa0pN05p6MxxhBkM79
+        4TltKH+SlMjJ8UY/Reun839wFpW4ZJQlhX1EslRuN7iiUl1T+4qCjkul0FEo
+        bnyUV1BF1BDsuoc4+9eVUMw8ru+7pmKb4xFH2MFaKzw1wqtiD9StdXYzGxsL
+        e6Fn1bXtRHJc6Lb24SmbXLHQlbEtQbhVTAVQQ2ZM3Ic4rz58SxTln1umIA5O
+        9lazYzjd7u6X2gO+6I/02z1CzhyxwDdis4qshaS7qYUB+FV7Lxib9GRNM7ou
+        Ua5ImeX867NW5Kg5VdpTlOa0ONa3YZye3H0BF0wknK6rzNOM91R9neow30P5
+        aeBi/Jq/s+7SO8HAqfCGNkBCz0ClDNrG4P4xJ4VXl6ZfpMkznmc0GfVF1463
+        JRToiVhTlnEEq/e0znLb3Q/AuRsEHVZ6TySxoPeUEjjDm93pHfkMP83qnJtk
+        yIeQwnLTjfqgf2zrpeAHSM3JTTZW407HGiO9/h5WMOk0vUndC4gUNpC7V+pV
+        x7J6kc+10PVU6y3zK4fIEhObc/HlS/I+nmxQPr0XT72CD2fp1Rjb9yfxESlA
+        Xl5LnQCbV0GE1oRU8FSDtzuLt7Cpf6XpCxShiapncCZbRaT7lH3I0ajuKjCG
+        sodWkWaShvomM5giNnUGijyRtKDLy7ckUDgI4JIimAo6pSO247uaY4TC9hcJ
+        jYZFfTbpTKjd+sZ04J8UwK69+uaJb8W+ie6HgNS0huh1lcW3XSsg7vDihZEU
+        e9fCzwxdOdkGFM+lJY4YHp0q2zFPQa4RkqGcChpS5bqXF2QUmsUh6dhU6hnw
+        Qbq3u7N02kt+W+VEjNyeDMQdYkaTWW10Xcy+sPHwQeECU7wnMpBeo8n/Qdci
+        xJULv9D3Hctw+vW4Mm8Ne2iLRqKCHygeR4ea/kihR6qzCZEm6Fge2UlciqXf
+        tQK+fAEHIuggOaqIgzbu6AGr2FhmEqfBT3HJBS4muInpP39YqStOJVst2y4z
+        S+yxKNuW9YQixez6ALLV4EqOuC93QFXNNlIZE8lIFdivRjzmgvXX79qvx5VV
+        zmCAacCs5/vjTW/+uAYPzDxjd15V31i3VnlPcQD4ZXZ0NxjNk2Zi/ELTRXH9
+        Afy4dZ+1Jza9H9TwMd4hQDbt4AG5GRiF0xjv+YMRH0xcCx63eikx0Mq1p/qz
+        ddOzDQAr9IK6P04YOgsIkNlCnzCC03IhSiitSh6DFx9qUJqG/2YjrYqChM+h
+        JcTIXXHp89YKyIDYgvpJ6Oz1kvj61Jq+bg8/E1BdHtMoFHc/CNRYdB0JxQw0
+        4fSbxVcNYWZOYfV0Zs/v7idr19/kvux8vsCf1hjYPfwjTKD+ExMynk1ZqUBl
+        40m+K/IiepGSoSDpEtA28MgBvR4NP9sH2UwrdX20fdkSlMJWwLqLLvY3eqiX
+        oRwh6nVfVNgxuCrqGcCPn08YJreEhERXRyt4TWh3RdsAYojH8Lgq70iUhING
+        o94Jemea6aOLVfG58YgcqnSGXyPSoFUy/mTFeHNn5xFd4wCiVl2z1ngItLDX
+        msctJNeHiOGDkpA9RqD8w4HOFRyy5ktdThbF4G7hEao1Ax2QesefybGs0IBg
+        h6hKceil2j+tOAjRsTzNOECilfBvHqj6aGohgv9Ndk+Nt81i5lMDyVNHjUFx
+        6ODDGDYwH3okDg6C3KGh3oIW2mmbqJysUFIkwy6vTuCP/uEgyBR0Gu7DaVUK
+        899sC0Sh9P+0lfxPW8n/tJX8/9FWMiuJ2FDHb95i0emqtFh57uRYwlhasvTo
+        +MmuCTt1uoj4Pz8UX4XomD4OxWqfnEXYvZll/IBPVWUJEL8YcQTfFjcrMOoF
+        AT10GoU8OJfsQVK3QXNnhbo4BVTmifzMhHyXucs9p/6cEgKyCttYSeNGL9J8
+        UXFWTn3mvMwXZ6ukKMOk7uIRdtUJBoXLolXgjZaOyt7rzSKov8CmfHKSJyOC
+        EfUoicBeDf06YZWzIj4O8nUEsIuBmWKndkOGLBS5JugVt/BbWhXU5LnlRsAt
+        r5Bqd76FO/GH7+x8uOFbedBZhS3/kovtSGKZcigWa/nGv/aExP5wMJfu7eJv
+        Oh3GlwjD18sxtW1tGKkedLOeAfrkOEhbPEmvwfQTXuZYsig8tPqRkPz3mlVT
+        Q35yjEz0pNXJ3PJEAba1KqaadpdmoGvTx0zr9/xuoBX2SW91sbDZJYoOexos
+        mYcvI+9wKm4Os+pgrxeheMh9hK8/QLvY849W1ia96R43i1eSu0PUYzB3GlC9
+        25MwVsXhRojdnkTF1eT4Vi8hfrr8GWIvvQDHGbJa7qO9Xdca8ngd31fVHl8l
+        urNb+yZRKzAH2juu1bLhNkB3TbhVB42hcT2nbASGPsufVE9ptBPgvfr4TSDF
+        u2neKvGQ189CWV1Sy4dlmPL58PvdM+u42D0DDBMIVc014PZ3cVNW3Hyhv9zG
+        1Ut1u9rUfLBGI+hA5twWT1Xu+OjiyTx1t6SSH2bQ58niuEM1cWuVL6bbi3ID
+        JaNnVz6X4+7jSrK8qXu0TwRxAiPmCUdt4w7drAZJ0VZT7S8qirmRsXtCUSq+
+        B+JncGLUfloDGXcMIpY/P7Sae9fqCld4H585KATh182wS1HSU9HCkRD2LvX3
+        2SFuwT0mSj9KRrz6aQGI6s+M2mAc8JGmjsO0slEFGCrqFJnvOX0cfZoYZfuE
+        gshkZa6r1SGfxFnzyOKvI2ZBO0QtS4T6SYFiJnGABVqR57CE+jeyfrfHMF+x
+        tfCvKhVO/z1aypNFKlWE+WmYU1osMZeFLTe3agwznUsTPulnBoUB6NUgpnnF
+        3ePIXut9toAMjaxNjy50yMgVTqS2KKuhPibOlM9kNOB+BsRHilWaet9+6Ppr
+        A2d9Fx+ms4nFJshBbgrldzc2AsnIrB0LGI1U9QO6D2miKPzr9PD/2VaCIv9d
+        W8nfUeK/tJVYN/3ikWKD+E0B7auVYY4Bw3iBVEmDrtdTgA/Or4k5+BGw7Ap6
+        q+lpkZE6N19WT3+hojonRDoraGfnTQdfCSSggoJZN6KqtiDXwKzb5v0A44xk
+        jt1vC0VF6Ce8+LtXvTPQ8KB3hCKpSo1ynwC3IlxIVGKRo16F8KXNbS0FDZiT
+        sKeZcbJFAWuIXqdd6iAogbeey1RxPIoGXQYfIHGM+rAlww3pJukP8/rQVfAj
+        jdDVhXvEBEzASRCW0hnsaG9soOipPMJAwr+fNFLZUYeaxRv3/LP7OvmJo1uB
+        tBY+pLV8JRDaD8ofeqHJO9R+MBZ/YibsF1g0jrsvIv+oX2YEZsMVfg0GLIkv
+        ZrLs1m8ImKfPPVaMw11jyfBk9OB7fTJBrs4HBQY4Y7nrGNHDluggWkRppVtl
+        XQkBM3+2l+SwA521s+mG5oFk646ptl56+3Who0Yi5Dpt0maYaCrsdnaB5Rd7
+        n/Cc2Q7/JGMGwoukoHcKL2/MSjyoXENvqy40fMCMyZ39JHTO8yv5NV8WsbtO
+        USCyqLygIdG+234s83xcjxxcITsP+/KzfeqUpAckpK4UGGQ5N3xlOmbjHE5r
+        HZfVk4dERxNzRsa6x/j5ZZirIWd4HvIIYnRVbj3sQs9G8uv7ixJZ08yHbde9
+        nnzQqOsXBDoe68rGfFhDJAeVYU1Ja1emVyWF9dj5w9ofL7eGojilHI5S/y0r
+        S7jfKa7638RLQrnP2uOrLW3MBUFTFobRtw4cbLhbRcs995gAX2EiZ0RmqBOu
+        /7o1/xkBlHgd8BauQ9VCxWOX7MX5TxyL6ke9161VVUsgtp8xb996SqjHIu8N
+        +S7mYgOp64usp7qP4oKzHy6VLdx2lusHdM3vLb+2ddjorQzDuDdc1Mg3dgs9
+        h8NgTzY6DO0cJEgL0Mu0AFTjn7BXKokUjbG4Pj3VrEbvmfqTOKL7ddTXuvMD
+        at25TaCiwnHx2BE58bp9+o3yrLvdpuFcAINa6J2hP6ugcvnOy8sARI49RRTH
+        T3zgldYPQTtBjicasU/0Oi6NnFY6BjdQIDriE7wWvRx8gLQqS7aLcv/OmD36
+        /LSHJJZ4xZW6utDQREAADYt3Ofyhc62k3AaDL3f10C4nNBrJzfJEB7oEPyEf
+        mU0YHUF89DmifM9F+z4/d44+a2t+ZAGIMEoa0fWHDWgDX2nBmz2h2y0MU7su
+        rs9JcihY07vlym2E0DR5lPRDAoF8wV8T3hVSAaXgHIwdtFc47mrgzOWjrQhr
+        t7HPcLQ0DLXkgtLQwqIwT3942kUIBD1IGkymIAdOdxTA2ylJkdWX9hegLmbT
+        uwc9uJ9YVIaOC3F6cbrTcTQaPi2x3hZBDP2L9QISIwNqm+YQTtXZdfO37AKv
+        uPCLP39vJWHcWn/8gb2eCtKV54JqFlKLfTP+IK7f8IlwWg77p7ciYjbgT4sJ
+        OykONSvoVvNvfviTUnze/A18Tu6/fu5XuOSPTk8g1/P3NpLtTxvJNyjiWuWi
+        KBTcP+0YliI4VK8O/J8Wk4/H/Gn7wJybeTEQD2PJ6X//0WJS5wrzp/NYdd7J
+        Tiv/p6+jGWLmz/j8bxBO1hHt+H1A6dQ/LSa8/E7HfR9g/rSdGH9vMWHsyaFW
+        tT//PBB/KOdd2VE2zJ92Fu5PqwYa2TRkvzHpuWhOUfaq8cODap00E8hCnB4J
+        9r+33dxy1arH8WeuEOMrrwInf1pTTOwH4r3/zokM6+t9cMFEyXDNbjaYhs16
+        1oEcFZo4mhOAnqu4o+6iZUBX3leLrBIcjy3wxmG8TzMRl+p+Gsa/Et/xIB/1
+        5nFc/7SRBJvxBoXUjA5nHuOwBOZdBBD1f+41HZP/ufdcf9pPXEv403Lzyco/
+        a0/G+N2PUFdc+nvqJfFWgC9FCJ7LutjvNAP0NcrE3LyFmXkL1E2B3xL47NFJ
+        nyeZkiEK5vkUAVu5xLlcRtGpA2iFKQhRop5iF98e5axW3xl7KZCVfhqalp13
+        MbsqsAmUM8EyxmGwGFqe6wwYDENNhoj8Na6Fk4/H48vXquzvAVk6J+8LkX1d
+        jDmDvaRViLOdsnbMGY7rdxM1/+gbh//SVtLdSXEzdSA0ItSY0Tm9LmXTwagk
+        oJy0sxGglxRcDp4BI5hlofz0BspFZxNhpTSghS/x+4oiaV1sIKHJZrOtDYtt
+        XdzuFBKikjIfsr2cH5Yt/lyp5JjWbS/WHFiByUBIspnF7F6rf55BsQ9hHrIJ
+        F5PnlwFw20EgQXsZK1WLLgOix5/OCKfCJV321G9bNXAXWpP7ZToOCNI4LlXH
+        wB3/FsWudmZuLXFFsGwMAm/0OS8fvavjGhsDNbH2jHmgRNT4a17OI0ZxFND9
+        3Cfzp/VYy+e1G7p797S6Jx4YAdM+btsmRcgLfXAhcvjBy2ZaH9tWobwwbJVG
+        TU4V6JqwwY0z6uVbZuDjwzPgfemw3kbva4WmvaBdpSOmDGSqWluKyvnNFvuo
+        Vnszzw/YHcXy/QS6ulBWB/heh7OyWAkCHd/ZFNpwHKRJGOL3d95zB/ixxXmr
+        X6SOQyW8X5/RE9gXXeoE1EjH46T7EfgWBh3f6PqnyjhCFPkat7in3J5GXTP8
+        I1FJo16DWR/CRihT9+6+4VqXuHfFAfmyWjWJ6L0oBeD4qA+J1zOs1P9YLf66
+        POzkyXPsqUHGUwSp+7y3IbXvZFnWQ0oA0Ry1gzSBmzxrDuY+XbbLW3LtEga7
+        9ZqEGKIEOuAGsbvlBwgR54dnDva+I2yuKq0uzSogagEwuRDaLnkpweI8EKKt
+        Tew9qpiw0oMapeE8R4SR1dOoOyk/EPdABlqSYVpqwbT9LeTPj6LTOQJnJL16
+        wYpPtMx3WhxOS0G1DHhtjQmT0t6apjseyaOSSUgb/ioRPvNQFogTO1ApKAio
+        v5I5kt83ln/+hv8mjWTo1+vbpST9WFF7Xud3ZQ60Sx/3GUDjPWzUglxSPhqj
+        oMfs91Pxs9lJNY8yXo7xNYMyfE4xtYmAvxykKwIBveFHXyle4mBKxyrcNHQ2
+        x6rAic0YRtpnKuKwOVbzEUHEv/zg2y3YedGTUHD5SW6TYHHfk9YnAeA+J7BM
+        wsHvCJpDH5uFSOLoFG/C8xxVBJBKD6AtuASxo+hzsgspktGEvirWwNIVVc/r
+        JVlp3wXSO++5wdulXcpNzmpy+eUehxYpjx2KpLd4+K3lQAHyrNZwcU7yeBsZ
+        KBzgBK869gLS/CP31gwo6Tnra+lGlrKe4a1qRm3mwJb4/b358EIQyxr8wpE6
+        QjKGxj68kkMSz7PpRYeLeAXhObmVfOOayw87Xt/AFT72tHbgUyd3Y21WlFO/
+        dNCYjdcM4qJ0sK+08aUQ8ymggSF2lZpMgbVowU/vr0aEde2xQL48tuFPW0ID
+        FgkHHJcH3vz7UflJufgml8hbmIztzfx5PI8iL5I8uAEVTuGfwdy8+Q16zAS3
+        cywyoScpcq+nu1A605nE2rOhkHNsHGdL0OMPlJIvWs+Xn39BsmTGQ82FrPJN
+        16ja41Sw+sm9lmon3Ml1MXHAfuPIPlJQW58MiJzpBW21BrUZhIq8Gr0sws4s
+        Spe8pJ0+2+wpYUOY3F4Y2FIl+Ia7uKl+lVzHjh3r55lAX7yZFSd/wdHPy6Gr
+        x2rU37lQe4tE1gpaLi4plUSre8FXEtleEmnlBn1YtygFssA4fpc7vEQnaT9K
+        hZaaE2byB41qdR2mBn4Qu3cxhivCS+HoXSda+CP8tMx+9PULLrehqDkHR9XM
+        lDoBUh1m8T6WZCefy3kQf/7+LRaNdXP3fEKnMBU4ebjhwWExkSD9ED9J7dLT
+        OeKTEgBbL2YigHh09euqPRLo4RKCD36YV7OVTkSux7hc8MGyZlxEQ9y6ik5x
+        vsfGK9tmhybGSs6xxsnyNaGKkDJJ7AiqgvDoZsULTf2JA4ujQf1lODPM6PAw
+        BwEOAXBxb8EM9F+imsF2JrvpUWhwRkSZwEkorcgOznNFfskwVsOggEc+Twgi
+        X3NkTo7UYa9lRVaM0gaCqH72VCbLpyLKpfKhUgj5eZMS+J5dCU/ae2QIFEdo
+        fDTXNmp2V9eluXO96U2oiqoqWJrpRe3pzVw8YykXjdjWG1xXMqJg1WAT7O7l
+        IVLbkNT7O/hJD55DPhSekVVahm2RgWeFR289uDp36E9CR1OhwBc9+x4p/gEm
+        /Ne2kg4YCliSBItZ+lF+rk12z7Rs6w87EHV36YjYjQOTv1sWwFojzpS7f4OF
+        iFxxQNLvr51k3AO2C9cuuwv3yo/WFihH/e7DOwUcbUSm1+EjaP8xw6FRNG77
+        qgoXw/GtpUX1MyCorzhu2LZfF9sCPCCZuC9U7saKmQ8fUEKWHN0O97VBHOj3
+        8nLaARkloNTQKH9A6uliS0zSWgIdtGCd7mCqNUQYmKhbkqx/oPEEcCqynRNf
+        Fzn/2r9eAMC9uMsc+xGdRoPOW38+047/tLFnUNecyLrG5dOf05olCBCdsHMk
+        iqK8HKqrxfOXuYeT8TMtmxRdAyCbdktayWQVACbdaFCHIxuBeeYvxNt637VB
+        oJMkHcYQphF1P5hrs01l+f35Cd17mpeBXej0+N3MSQqZg6jPFedePNFmDAv/
+        VaglgpJMYu19qu0FQetbChnXK09bjLZI7y0p2Y7HhndUk0orkjbrcxMEDCFT
+        gvJ95iqHMzifPPJO1hRi56OeeQoJliRKgQqLHfPwobgwxhOc/cSvwPfoqvfo
+        Hze0Gj6eOWpf/8xwsWEg68a+UXrTP3nOf1y8xdkj2Mw1DQcxsypn2F1g9TJ1
+        vSUeanSq3XfRj3fUWchNf+7XvL+yoGWY+mOm5tQfKvmaTR65PiDwPE1jHtLC
+        t7PCbG4YasL78+12St3xk4mJcG+Neeh0BeIXnBqTwKSOWUrmg9kw2Wle2bCn
+        v+xAh+Wl25o4d9ZUzRFCl/78YtqZ6sjp06ApxVy0InSB2Ig9vw6SDiV1AzAt
+        cq56lRWkRURk0WIgMIV07S/Ih1HK80iEKrIsiyQ9Ei8OfkLw3r5g7ITQ4EsS
+        o1KNjmlFyYsypppsTbE2OGRCJ95c5Xp0rFsykPrxYlp6vdWCvdccNk4f5eIM
+        NZJozSiZbDgXa31Qf+0RT7aapAWZrl9Fbmr/UIrECEtD43v1yVBRJ6NX4LQQ
+        +2F9cZwxDjW5FlD0rBdwkn0FVy8YLha9ha3SXbJDrzcT5HU78Px6oiotA8OQ
+        HUxCr0tkpeRiyQaTpW+rsxBFZDOG9cOrRBtfG8DTNy6X2gr7JNMTK6nnDJb/
+        GukadreUTofKP8FEGefsV/Q+Yn1sWfvCWen8fsZEqRX1wupl/K7YM6QcwPm2
+        b0EVOd7RXsDp5LNeXqcleNt1HVZ+dt1m6fSCEwnyTN5FOrownumezTPUkky7
+        I5W0+yQuPlijhD/HsHaQexLfmjh3qxF+v54pTOvgsOhTN+dNFrJC3LCOpMmv
+        4jgynyafmc2mjlr96Wtri7T4mAGBXDkeRWdGh/DdeYzY9Uqd3cTU07jv76Wj
+        xX4YIKt8sZbdJXhrkvSiUy0Y3iVO/nPDuWlwdBLySuso5g1l5BM6Y/hAiF6Y
+        UNwqB+Ej5kJ+FINnsSk46+zdTQKp6Mdjf1IGEmVzy7GhaSiVDvEHPdT6wmNz
+        v0nmNAomPQbdA3Ir+Jp0uWUEt/Zm/xsF/gt97/3InnonMJ01vPhjH4p9Z5xI
+        XVj2oVp/ZMNGz4/QIwrpcYJL/01M+jHB96hKskIz3dPp8fXTfqAR5yzZcec2
+        b3g/J8Zt1KdB7mnMC9UHxZjanm7eyiMqVWZLcFx+aOBfuyeu5X/OBcRTB7U5
+        HwrCwgIU5sZQdF1nKU0qWbaZzQXpA76Cgz/o3wx2n96XkPSnqjeImWNh8q+Z
+        4FAiVscKnKMPCpvoB2FxrSfMcfcOGIfqbDsMveeiJwoBOWEN/IXOThfu148r
+        qs2/g7TgD7g4a7Q/oC6W971YFpcLRWjRPu9MdY1YxQREg0HQ123l3Jv5JMRK
+        IurxCjepgHIgxnNDXB61zjMxlEoKhlAeNYuNs8Oe4OOS3+tzHduluQP8GhSj
+        urNj2w5SW/aevzA6viBL/c4dAWbYTh1GkJ96uEbZUTTZ7WL1UbYfaZQIAb00
+        YWXVbVSOqrc+3Oi/eVZppbegBJkB9BG4KB0dthT1jOR1YF4rk/KEapp5t9rH
+        IjlLbxXnkKqJyF6yX701P/QrNPM7vvg6jyqnSHf+JdTsopax6O7+EAgFiGpo
+        8XkJo4mq5A/rg5YZk61yZrfHrgvwjzDhv7SV3OwkwIRh0g/VWps5sVXx+0Qs
+        8lDSluQJSYxv4n/w4bIV5JirfuVo+PR6/hcB9cXlJFrbHS/L2OuPbbryL5ju
+        frZTjC8ep/NRVl3TPzfoUATJfsuXYqkP1r2WKYLAaaHjOeILqJIug0+OHAJh
+        rN9H3QjX48d/s1UPyYvZ919jR2r+xasTa0bqM/C8aSwf+niva40LtV+XqbUf
+        AB5QWF3MhI75IU7ioSb2jhGtfXFyesMDqwrFWK5D2jedu4XmygoFonwEb60a
+        M8gMzCPirzgEetvJ4hdGyLGUzS8MBFNCYWzxHnSlpQiePE3YqR47x+xmx75P
+        XVbbq2WhgWNKobp7S+/chHkS8joBNLZW76NxvEgjEYO4trGWIPjDZRr3QMm6
+        /6PN5H//2//+P1Z8DtH7RAAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:mt,id:Server%20Availability~Server%20Availability"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '148'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '354'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAG2NTbeBQABA/4ozWw5RmOwiH6mop0iOxaTxTE2laQxxvN/+
+        bN7u3eW9i3t4ARKDESC5wDkvWN3OUMUxa/t5jjIcN/QiQyRvZ7y9wUxg1tAE
+        IhRFhBJe//zjQAvEiCMwOrwAJxmuOMquYNRVVNjvyhLsKd1eCwhEb/jzXSiV
+        of0x77p3xCau9oTUP68dN8G4FMXen8GxIr5PsTQPepPI8maRNTM7crgpm/bY
+        y+ZubcN0RRY89Tyr2gaWa2kJ1QOvYFPTMi9eOfnyXOwEHls6frFJLo94vNf0
+        YC6bjmTq6nZY54OpFGyU84CGT6vaderm3l77algbT0mleknVAtYpZ8lQ3vU+
+        JY52g3DwvLGOqfi+cUf0YQy3YlFPTywtgmu8vcArL/tBdBOFsbwMm6aOJs4s
+        W9lNQW72lNHlI7H0PoZxel7IfriE4VhzNQ28j+/jLzzl6oSZAQAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/metrics/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAA3MvQ7CIBiF4XthFsJfK3Fr1aqDizTulH5NSIA2QF2M9y7T
+        WZ7zftETSnI2a0gfZwGdkB6713i9oAN6hM1DgFhMcWvEb0i5biWU8JYwMrho
+        fHX97nzBQ1oDvrmC9b1jFclmYlJZJSTMLadMLawRlgumjpOUojUgOVUL1MDZ
+        5GzinEy97Rv6/QHfcrqrlgAAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/availability/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"ids":["AI~R~[8e01c5e1e71a/Local~~]~AT~Server Availability~Server
+        Availability","AI~R~[master.Unnamed Domain/Local~/host=master/server=server-one]~AT~Server
+        Availability~Server Availability","AI~R~[master.Unnamed Domain/Local~/host=master/server=server-three]~AT~Server
+        Availability~Server Availability","AI~R~[master.Unnamed Domain/Local~/host=master/server=server-two]~AT~Server
+        Availability~Server Availability"],"start":null,"end":null,"limit":1,"order":"DESC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '466'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '204'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAALXQTwuCQBAF8K8Sc7Z0S2sTOghdgk79OYmHKQdccHfDXZUQ
+        97MXFUTU0U4Djwfvx6QdiBxiSDZu51JOATtHxGjB0N/qM5bOZS45uD1VDVWj
+        pEFR4kmUwl5/ZeBBjhYhTjuwQpKxKC8Qs3DJIxbOQx5M5x40WNZ036wv0Ge9
+        9yGQaCxVk6NSKCkfrbVEoV4Uv9DGrp4N3zzWV88z1ooGdEY8CGZ/cdqiooGl
+        LHxLc92q4aytHlj69dPsBhRgiXN/AgAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:r,mtypes:.*\\|Deployment\\
+        Status~Deployment\\ Status\\|.*"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '144'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '13705'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAHyax7Kr6pZm32V3yUi8uz28Ed6jbOG9ER4yMp+9OLfMqUbV
+        XR0tKQIEP3PObwzEf/znnyb/848/zXgU4zYt979TBQRneAEXJJz8+/Lv2pQl
+        /X//959/+5MnW/LnH//xn3+2ZijWLRnmP/+AMZrCYRTCYBRF/+3PkfR78e5N
+        xlaF+d9/JkwnqJWamoZEsITfGy25TfwUaLz3NnDjrmNe30HH0xOfYdULL1u9
+        UXvy13cLcoeBAjq0xhb9Hy98zsaOgpVc/YZJ+MvqkAqSJhQcjXZnUJV/ULqo
+        R7yrZ8nyRpJ8oBE79Agcj2qiOK10uAwcxVpKVIYMaTBVWgDyYxYEy0IW6IPD
+        PRybd5ECMULbs0QKrKsx6TjF0eF2LIynmrxMYgmkZOjgtqIgE7K9f+Sc5mrp
+        hiu6W6LljI08gnoDWqhZWGdoximIHSka0bwmUzA4saBjoRQUHW1NosIyE3Sx
+        jl+TEizdRB/HuQknjw0Ofb5WeRyETMqYSg3PfEp7iq/TIEEUTH2nWB2Gjx2n
+        GmSPblCOPQ0cBwoaLquh4A88KPw4srgceSzdJO5I18wYodTP/f2T1gjbHO4k
+        Q01KjV7I6I6m9Nr+kZ6YviBxSORjn52j0afvQ81ravpYiJQgQGMZ57JmvFQk
+        k8vRY+WSBUTLNpG+owzHzSbQEJDOckblTtWnRmH8hLr+h2mueGWsI9G6MMvP
+        GSHwAGR0tLEAUnuq2YGCz42yzScu7yu3Qnq3UhYR9o9RLc8i6mHF0l/vDoJ9
+        bNYF5doscl1yOCAPCWfsQkQ8WsWCFj4ccqq7+amgj44blMOtmro7BT45/DLN
+        HzquIc0JpDHeJVBYJf8CFwn9sa6vZ2Lv60TfrTcklvFpmWV+cul38VjU9ZjD
+        Q0rtrR/lo54nG4cE49hqjVkYgdOlFW1miVkqZIKYBvNXnYD3dzfkULvyud2i
+        b8aL4RAeq0TWdcSwJ1CZoReLyRCvXBzYpvGsn2yi3HAudGejq0NxKGorJkPY
+        AJsRtWKF5d2fVDEYtytASh6aIAXNH+zWjPsS2QtRQ5rAExxhOuzHYZm1wynf
+        HvOCX8Iv38XOCphD0xz4MDMjW63oF1IyjVztbiR+yBLWdVgQVLIjYFHkl/3O
+        czZGMRkkNCJv0g4GBeyLZrFMWMemdRfHbLlFNdOMGzz7p4G2TSh9+zuh1d3K
+        FyVuywkC9+sL7EepIF8auhogngEyT1iZc5RbH53RoqTINPCj7dFmoivBR80u
+        PL9w6zaUYmalZ01LM9AQN0Q6TsTBQPRecsEq9IPXzgwLN2qqAepIc/UGZ41P
+        MSffQpEGG+GduSPCbdj1SZ44nXNAHRJlsnZX/PM2NwmWJ/l1kVSyzc3J2Y1V
+        At15qFNif/5nGG5e4gSjZMTsJhd+oFvxy7Xec1dGAhucIQd+uNFQsPCNFdc8
+        zPNF0nqax0L7qRY8+1FtHZCsLZDinQ+Yvagudot+Fgn71MFUt1NBapYrvk4/
+        ITIHj5bxZ/QUHW+1o4OMyQHlixRE9aMmHbJHNWgcPbGLC+l0i2tOfVtEwNDg
+        o8vJB1ENTo2eMH4rl9LmV0NvJGxUVrfWTsfuHBbE/QK91Z/vHRBrMk8yjXu4
+        jfgbbu8UP+HsgwrAxzgNnw81QvfHMe98eYctm6ic7PYfVuDAkx34RyavlH8q
+        D6RUd1g7O1nKW0wzzIa/t/tJEzti7O1TjPBhsbW1UnmFV9kDgZaTamRuLsmX
+        O53P+fsBcrMUxxox4RbZ/q8SdNrCJUkE9qYx89rKEm+QxipcvkWhUt3bXBKv
+        5tMWIwvoaf6OcPcZrKJtT/lWmyYGWA8kIMXMPDEUSR3Jfm6Xgu9e3XR/WGix
+        pKqSbEOB3N7F6KaljRRYKU5gESyY4T+rpfecFNilWunGr7rdKv6GtRZdde5L
+        gLeav6qJSxmuDYnTyVWZTkP41nTCsALJ/iaGoFbxV8nPfro/5jRJhpjYs1+5
+        xe7Ur7xpy3NINAxXIfb7GZlU8CSPrHwZC/rvNO5MSWGmGOzz/LHGp67bhKFr
+        SQomBqDr0edSD2dXUTm9Ea+WkMVGXf3Zrr7T7cWMC1CoPhCvbqkjrMmF5UfR
+        kBbmD4pEEUz8nG0gt9xtxIHpKixcD8J7JVdraAWJuMQEYpxF5MP5tyiTns4B
+        J9ZIp6y/hTcgljtXTXYtPTm7XMk2jYWgynKVEIvxGFOfk7z4APsuC0OtAtN+
+        2uEKJpaoMOuI6os/X1rYkmr984///JPV+9i9//2h3w/X5vkLD15YIOg///Vf
+        //b/ZQnkb5agPgfDHO2Vh755WP6mCJgWv50KBUZsscszh0xmVVXT6gzhM2Kb
+        kiB2Es0iI9mJLolIxyG59TC05x3hYGkW+UKcxzTL2eahDg+DGCvJejyVdF3a
+        6ryBeRha7XzW2IQ0o0YfGyfNcIy+F5PHJMY2Ai1vf9Y0fnhpmxgImZMYG76f
+        06tJQbDjJAorZk2T8pBkKIjBZ+CoNCZhZt1PyoRkXCPhI6zTz6r9bBaKm3tl
+        eM58ytVjzA/kSg/7Iyisak1hU0yaHGsjc07stz7vNWHQNm96O868sHGU+EdH
+        FeN/5zIdeCrtcLwuY7X68f/M5CcI5ngfBa3vajitFRHOWD/9UQfPZR8o1x52
+        +EC2xBt3IpxNm58Hoz6VrCrDJ3WIIrI37cTrnHu/bhnDhhW+PyNqGDuYS3Jg
+        qXQi8a99amEEKPC1mu3GiHgo6VrVra2hEp2ttRs366fQbDq6nkGby+DXZKU7
+        5vprmJw4qHsO4z/240itwGGk7ho6Xy0cDOv8B2XkMcnr7thIBmp1pLeViA3d
+        /BPLTlidWTweUc+v6Si2nBVMWI6qUTLe/sQhxsP5bP01EllgmygIGdYZgnyI
+        9Wu3yWZyhIY9I9aQmDE17/ukPPyiQg8nnCRb0o/WR3G5RIgD/Do6t6CRDehr
+        P38Vb2wiouXEwxa19U7Fww2Rr0Jdc1m5JXVNSPgReZ1xewbzRLNKg4l+8FGX
+        zyfVg9i8a2oNRzYyZjHmjvPpC8MfCEOePVl5e9aF5pe4bRr1mKpKZwADhB3f
+        LMCgVqdPwUCIrGVudZ/B6vrC1evDhGOGR5gSI/mX6bvv+iOda1zt8sKfDZzq
+        1u7YkSoKkI375o02FjPC3/4wt5Fx4Ns8uy7Suvuev7zXZmdVB1t1P4AjJYZj
+        MW2xe748I6lVpafaaVP4gGyaUPZ3bwgyDj9sipDBwgaA8sMUfjrHE9P9WJGs
+        6t44Tj3Y8Z3aSSZNeu1HZ2rWurxUKM35Vsm+9WYnJt+iKoPQsoi79tElwche
+        5HtoqG8bQyZ1en235/fzdmRbneyaTQAHQeoJZqIz32yPfUiv4nHMLixFtOzm
+        ME82cnjHwGADpnRfe7TZlH9rZZxfXxIhRyx0mdaZ2z2tsPq0VpXXlT8A7A2p
+        FZbx+XTVBSYtXsPRp06MuqBV3w1gNNTuoVDZSi4gUVk8hfDx5Tqh6PLBld9K
+        Np8WU0+6IYDbSvNHy9NnlxmiI4D+B2bH8X5BwiEbIbDIfm6NIpqGgrwrX07k
+        2Ub3ZwAxgUjTU/Iq2sCNkRe0Yvl9kSaXt3WbhhL0lhJCONLuiGxUXAY99+zI
+        oUVva4V2QAkx0/GyV30upEGgn7mvyTTG9Qh3qQ/W1mfLycI30l0qvs96pHmB
+        z3knmeVwlE86WiIa+w6RrfbsvrSgw2fgRf7yT5OrfZwa4NbuGHm7wJMngb4J
+        vIAdYbSSAuzMAWKIHQcU25JYGiN/qvbIz/pETeHOmjiIfwb/8hvSPP6jKMmB
+        GOkiow7/2/Y63FBm1GzMI36OtqZHgjXFUqAFwXrzrMtBGsK+3hhwXKAXRTLv
+        md5FEVk8jP/OhEXLAVXNY1o/remEixd77xy5aC5WvRV2OieVsQrSQkPBiE63
+        u/GzBI0i0CNF0FTIUI9D8MPLhJ5OyyvYIwRd6+jpLoxSfHiaPNBnYTCrjToH
+        PEHuMHiyBUTXFksLCJp40ALLIrj7Z1wGdRBtjwF7xHMPCSy1IJEkLqy6dGin
+        2FFmg1YF5DjUjuPwBMGBQ+XyUMsPXWa8DYBmEld7XhjwwkQEZYoA18P4ClI6
+        8nrRlqLYjhgkQV9zVUqkIH5D2V4m5Z2ta6JXBr+9LHyazWbF/lkZhSDPaQDH
+        TChuHhxXSQjVQc/WqdMnCt+v4OL36oxEF3UD4elx2Dfoq4I852/IJhHDK2uN
+        ZorW3Lzxym3DZR25jWSLHZpHy581fsnmxGG/kK4id5a4+u25Ck2MAxBSezMU
+        fJXkyi7Re3YnNohdu0jwTOYSRAPdJ46adiPb+HM6CkGsK/VtUIAWLo3BEgwP
+        Co6FMf+X6cPyZOBZWs4HYeKuTdktnvTnz7/ABPhvTHC0J5kRA8BbQsdtzY6V
+        K+wZJS7AfWD01C9HpkT79lsIQ6oan/y9Tu2KMFv0QYeGjAFsC8rfg6us635i
+        9X9p9onRMrQ+fCowuyyUb5++ru0yD7fPySdtUSBD0afHEOPlV7gQwk+Chpu7
+        oIWlFr1TDIeTpACNiu0VUwOlGmJrL1iWakaG1jUTYsjGs9CxXXHbB1CGhALb
+        tkkStjSg52JZfQcTe9EREGTizIIhiiAEjFt/4OCpRYIQiAgDxu5glwRLHeYE
+        XzdMqkXnyxYtvMfKfvWeWEf2l9frXOeBz2HPy/KoVYBsNMhV268hPJeQfjht
+        1C1utsgmnVDfznjRRut4TtlOLBavEaZRwAbb/2Rz+rX2PddkEqq+xArw3gs5
+        rzXJ1TcB35li/P3qlfZt109ZU1ca+HU5mbborO42mG9tHFm6jDj1kZIJxyL5
+        tCV8LRKdkR9cfO0YHO5y9thD7OF84IGFU2ZdocP2cmPvzRVWvxfYVUR8K4JJ
+        IBsSBHRf8T5ecouBH9PTu5BMb8ywOzBmZIO7bnWha+6xkawaB51RkHz4bzV+
+        KFvyVJ78VuxwTb+TCawmrNuyEI904eP+6V32UwqF8u4tmF8FZTW0eja98aKG
+        +6XCvSmcj3x6RGHm1VfXU3Wx9PxW7u9UpIfptdXGeuKAH54D0fxnZggR50Ab
+        m9+hOVdDIWjI1v02WWyy6lQ1Zdf554Ut7JIvI3lG6yV5Xplt3X7Czp9/XS/5
+        45aOtYdXcQg7Mkm538UX5J/3CRgHcWNqkuVcre/uxS6mO6XzApgMMUJOQ/GE
+        fIFQLbMNkQ61DKLBLsy1JhB77jrLvPnhZ1OpUlcqf6zN9+xM5OY+oNv3ELFK
+        uX5IAdXb8KXaRP85uvhIyhbNBI1CDTiMGXU/lfVkbsAA6tqdARG8BJA0vvhY
+        z0sp978iBnbs6sPG7YEsCxyv7KyTYfZKermpM+yq2yvhbFknZ6RmZ+6E7e2M
+        k14FcTFRX5qAXrDrU6+Wk0cj5VvNiXwQp6QoDH0srrC8Jr3fSa0HX6LfSIPV
+        D76qck6XRlb7CZMBcIuPDZbOTw+jk0Cdab87ig8dpQtARN4gSZL9W7Zhb6B9
+        qvv94TF4TPljCvVXUTvwPD4kc2+0NsVNWr8R+T3MlnQD7Tu7aASyKNt73Ns/
+        ++MBufIjN0o5vF4Zikxb/tJOCGG89BjRYXMLTU5gFQWFzc1wSwMGONjlTujZ
+        rT1WXOdAoRuUzxfjTZva3znI8QV6Al5DzXtZIPuhzBTS+Sy7Wfm5LYbtKB1I
+        41ZXlyuxlAD/IcmbAU3IvndSQQkPHCcLQWqJ4kIEYJfeXTCUTAsppZyoJK0T
+        JtSw/lGVmuYWE732LCZrQoGpduMFiE3lfq/npkm2rerRJAJPqBv6YD2KzyXu
+        Z5XXqK7KSY1y+SmoQwOO04XEoDH5ZoqhG7VgZW550QJByoeRDwP7GLqxuUh5
+        3cjiwIjqokM95PI2cXikgbUNdT5r94jlmedDGGVqo4vhqUjNAEMtU9W+I6Xk
+        1bFcFJolbPC5RHKytgLB1iIWXdHw4zXSKFCnyoj2vwrz0ilU4SHTirlmogv8
+        q8RtuDE4UcI64RmL+fwOPuJRpf4LZxkwP88RJLftjbsM8urV61r6SBlWZKKd
+        AGp53XubePk1jLpc1W9MiXDzPThQJrB1jFMWgUJZYYVhdO68hPLjqNWhW8gE
+        MAKzQugSv6yIAE3+KF93RKA8qQjQiMVieMeTkOZ3/ggPdSLCavqLig20MPwK
+        D0sgtsPJXLsATdDdbGpboFa291LdHz+Q6IMmrzgYe3fXPh9dUr8n8WmVT+7f
+        hfrrDJUnfqNZBF3Fnt294P66VPHhfer6cMGD1KDgFNUeDvludOG3ONjH/JEr
+        NxjUvDBJzXJOLknCnJbaNT/DpNM5aS+tavS5tV++fTUaNePIcGiQojb0zPcb
+        D4FddzvweyDFqkp42cb7ZDZvRF4zRdmLwKyVTnJDGl8zbarAvIQNQiuXV3m2
+        VJjohwUTZalaOR9QV5qFUNyreQBpCbzVBrzp1zvq0u+Y7ALEkFG2gxKvQNaL
+        f4UJ0N+YgJZX7ya89IQ/VWVGgkrRsXQfNIVqTkfg2H0zaong1z8NQ5h+nedB
+        bM4VZYVCygrnfeVXUr7de99xrm2tHAD1kHt9Oo29yi+5q5WWHzoQ7m4XeD68
+        q7byLZcFcb4AQAQ8q970DyAfe1sY3nzkcM70Lx4/oZSBFE3eLZ4O3blFh9dk
+        TNiE6Lh19NnfTu2qW9cVMDH5OTrULjZQNvp1hYSEWgfJI4HhzrPXbVRNzGUl
+        ZYExTrQHk92lvr6PG6qhkaieppFsBP2bGHlBkBquzhRWz5UHMKc1Fnrk8Ykw
+        D04LhKmm3UacHuo3PCOglZsqlsQpLnlA1btthgRLI8Fdq3VtO1Oe+h70vR4x
+        b4+9ZbLBfEHvyoIdv4T38WzkFhwS6eGab7Pzzq8RkJVgXxegtL3iLQMlAYwW
+        QOygJV/RVYIFOj7AilInqHAW8HCqvf5YLbJbmjWP7omsXQLlBy3jEbHFsJb2
+        1TcZSy19/Gokc7yT+xlgcouWrAivbO8WJQCqW6c/qGpP9Q+7zWcXw/762s7k
+        NIKTqKZyWkDuXamGG4qKFg+RdOlZfn/0BVL9Z4H1CegIhS4lHvW2WDrWk29w
+        /APAbmOhOHvLsJfD3LKcZ+MtuGjq/tSW+e9uCPklgT52x6/rD+gjssERIQFM
+        lhbrQENyuOOlMvVxXpixCmXwji8nPc/OBmOiD0CTPYrcrE3RpMv5BoqhVXU0
+        m54oDyUMA/ieNeP56WN2B4t6CDo6OHYjsbUaqLnyy97rPfY2fx9hjYqYMzyX
+        oCa92VSWiPSsjnYzMNAvovX9VxGzNKtpx/XXVDydxCRCmF+s9w1wl/mnglIp
+        PWDgDEAOvqKUy5J1cHNZ7eYkLhVE2wR8QeqPWg9x2YLfofVzEnzbW4AesO05
+        IWooANQH3PwRYfeAKp71UanBtEeVgTAWkbHxvbH8PmhSFI+IWhBSzc+JNHwp
+        rrjyQaktT2kpuBlLvEJU0qwEtrbKGpl2FDzIK5YUUpYFIkffJBLYWHzV5G/L
+        0Ih01MbMxE1sy4r75PVBu8JIRpd1e/udSzVu7a/Al58mRAKlQguXXt9qlnCM
+        G7z8++VeCMV2xp750RzpIf6wP3kvt1ZSQJxcP5jGiqGkUiTLlhKRYWf9vkRB
+        XaMcIX9lTYDVe991ZHZ04a2PFJNhmxpZ4DCmr3NU9ke3WrR90pi1lIt9IdvY
+        nMr2a1Y6b82sWDBr1Ey768W3ePFCcuUrTxb7qulHsWqFoRedrTvbviX7l00V
+        Jtr81kA6Kp/4ufN4Mtyyt1HlLjUOIeWZ5oWSfovYzTFwzpCIxFCukmUp06qu
+        os+Kbawr9zbIsLrMVyh7LRsA9tdunH0zChNA7mHHgqjUzr6yWDdVQGQbOVsZ
+        uSfkAyyE3PFBzpukfiYkae1ekaitUFel+ZUgIaeYOA0/58z2SMwoCzpCawky
+        BJCi/Hpw3VKWdwe/QfRq9n43F9YPmK/CO3y73/q1/dBUpkWbDMgJar69Cad7
+        WNvwoQLdzzA2oPv48fAI6yLYBN1Tott7YmfEcNSmOCp9lBDj01Jo4bFQjKOG
+        fjE/iD87IgaxgSpAYT7ofXm4P8uWsmexDBTRcHooRHt44rWKx4DIRyY+lUxX
+        KdPAsDerwpqa8/n2gJukGCHFM5KTfP4J0EWSC6gFMV2R5/Hc4ztrOOkTQ2Oi
+        6Nm1ik3Mqm37o07pHtVVe9nw2+5GKjKAUgvU9QCK2g672AEV/AwX7tR9b4wk
+        z5efryUOzAA9yLvvcuZEID7cWnyzMA0kRvg2J7w6UXdkvRGks54nVidzYWpX
+        wqA+Wl0Hvaqh7XuMdgRIQgE10k9nxFmCm7hIGtbyT7z4+RxeT7DtQQXYhkTD
+        UQq1T1Y01wutKOjDB0TlgINUIw03msY2SeIexwmiG9kEZ7+6baMfb+WcjPK8
+        fYZ7+uUx6YvmkdrvVmXQxv6GPGsILN847S9zSoae/YV1nTcXNnFaIQ24tD1/
+        xKKQb3XJGkMgpAYXj1AsH+2dJYpDMdHRT5fhMXcTij371Yi+9+QirdF0lvLB
+        I4hr5A4e5GJpT7gqVx0029ny4Ozfv8AEhP4bE07oCYsCOVteifr5rXLup0TV
+        QvNdCMixh704+h4i+m2kOAmukXfRkrgWOcoB0UldaP04L9KyHL1ZfsutMyXq
+        nviVLH02GA0zj/jTTtT+iuIdx6jgf9q4QCX09XqQ0wnw1RaN69KvOylgXWjT
+        nA0yFGJf+FkUvxs8j7ZfWcgghihbioI8HaC3PMe+3VmMlcqOI4JBcCNwqjRq
+        P6Nq4GtZq9voBBYDy7G9qN1KQal9Dk5/bhXQvDs6O6QArfY3kmYEyBSIjUfU
+        FbsbxN3yEB8MREXaKAHmpfXHGJp7ldEszGhQ7WsifM4gGnuWMhUnB72wyJIe
+        rMGbubU9vbPj+4B0VYP4NcaXyr/Zr7vWgF5dZH0wDN40c9nMq3S/jNVKKg08
+        Smvovyb0UnfWBW3hahQFSq2rlu8OgsNDgzx1zMQeHeD5ns8wBsQxa9TXOiAc
+        tPfEUo8FhjN6cvJrUSZZEQ3jgViMn16e6i5+CUZ+DvdGVQTi9kj2kIgUvd74
+        P+x9XGiiSylr9s510WI3IBkUN2IErB9q02ZCf/Iv2wC+GtQx5b1UsRQ6nVJ1
+        OJsnv5S2tMzhRKveXDwsH2rIIkqx20zrN9fLby+NlMh3klFcp1oaO921qi9I
+        61+WSEzt04hfdDyKrcRkoue49vNeT9zKZl+8dCWQJs6qDfEZ2aalKsnPkmVG
+        CJkBfSTKf12lQSe0Am4qtivU9yU3wg3wWabJDd31F3rI3Q4zh4NJ82u+mTAS
+        6yASundcUFDDnHd6cB4jVgdFTYG1BXRNRePJ4lpggRcje1RGN0Mm5kSzGW2s
+        wwCIR1P3llagdv6QnMtTGIyMVf1298kZFTDRVG4JdOynxkl8x9LnK3yFEQ2Z
+        vW96/mgzQK6BNmESClKUu8Mn9XUU/90AJb3NHJzul/4YaYD4HUKHn3mmm14w
+        S06xTgjBvkni1sNXRWhVAv1OhWgtaJTI6mMiR7UL/N0+cXCCXL92Zij44Zfo
+        DwdPNUmBN/F+1+iKPFuWuEbJMnJlJxQGcAKRRI5VXx3BK6JUepiiP55eamgk
+        TvSLPdqFzVJWRkwgFfPkyiKdl1btVQUNKisqQq+XjLD/7Z3PXLNfGe9Y7BtH
+        hpwQezPzqgt9S6VddmwBMQUA32RJlWZTXBUqN4ITNhfMyhufzF7yhK9HZPNM
+        9dR6HojM4thzPR59lpjkJ2q0SzUqgU8pdFs5kLp502DCWoz3harukZBhLEPT
+        EQgnDCl9FNmpnLFvORTxkrH0gaI6CoyiRHjSk+gbKqQV+napmfLVj6bmL8y/
+        5R4WiEJmSlW51cV9Mz/NXjP19AL51FSbp4LZewKBd0ScbgA4MSf2vJMwzc5X
+        OQjmM3H6ItflQMQ5UkULXxem1IjZSaerQNWMLNcviQlRSCDP3FwmX3CYcavX
+        QcymkKcQk3GsJTB6l/3obOG2x5SuMqNUsjFlxit5e1LysHonVJQ4yPG6FI1x
+        s5CuRhNRycetWMYusXpre9zQdiNWQfXbeFQbY2XXAZJsjH3LMIDkXLPBApTO
+        3C/qRt9zpjQ7vCofliHtmwJYaUH4j8DtS/xEz/2i7fjbr4g+GBYq5HDp0aNF
+        pMZs2Y7NGVFnO77RgQOVX7aklGIeX4W0Vt7iQfm7mBA57FAdIk4+4veb3TTH
+        BW2i0/QLaOEZjPc1oinSlANGATsjnZmZny58a8GTFc/V3ygVK/JzoWN1jkNi
+        ndlpfX/pOF0DCsCC4SBw+QqPgRWLt9yI8FhWtAKOutIN1wwvaFJD+8JRYILn
+        wY66Dg/qPOjNmH9jg9s7Rxn91ZXg4okwQ83hqhvsXY5AulsW4bd06Niy7u2v
+        8QB7EaBHK+XD/stVbiRxac74PxkY7TUQ8VEjX5k1nG9QaNSD7dgHX7+l8OLE
+        oZY53rbQcM4Mtf+C5x0sqVzAbLahH8uTgIcOHmoQRwpS0BH5ya//fey17Wel
+        lT9rBANETiZLDa98lHPzyXhTV0ikg0EAgEB+L0FoggnHILksBBq4Lq5Gr2T4
+        O0mJtK8j6KtR7rpMRC98yW29YaxGb5/0022pMJ/Ot4p5M+3hevwzFUPWhw/3
+        rzCB+hsT8oCxPTXFLDJ29WC+xyRTGbH9fhie2sc4Ax/R3UCV/Up1z0ixNTB+
+        s1zF9HgY8eg248ufCtDb16tFrkNrFaSWbjXaXiqrDIE+pPxJJQhxTAz4eSSa
+        2l+tbBsKPQzNkgkPNAHDVgBehsexJNozUEFLwI1CLLLp40VS7ueqBuiOWHBu
+        GR7rDmkNthWBAteeCI/ZT9TAcCKqLiWhT8DVzxHmvmaOfZzYgblmOxQT98dK
+        BsLm8nuMYn1Ym/ZX95kwyD9eJfSZZPfoUcyLIzpcvcU8jLpSqXNXbhkzqCOs
+        0oGTmmhMfhdmkcZbnSk7Ofxtj/frfoMl21PELwnKQ8LPQMiNKgDCATIeYHWP
+        cX2uMOiLj7jgr5j0sDSx3CYGhQEYa3O9u0hca4Mw7JUa8l0yqMDYDjk4Rgie
+        PI2AmRQN1gbhRY29pxInfOYobHOjuH/id0o/0upZmxbJEqK7PxHvhAtcaS3c
+        iU8ADJUjN84lbcQPVeepWr+O/44EOYuva6hCMg9lEwn85sfmlrrpDyxGpc0E
+        Pyfi5quFpbwjJs0bE91B3u0311DYbfiJfprWYwErG0Oc8MNUG7ONuVrewRBu
+        Hy0+6NQAqPYasx1rIy4GGufTgNOvAcdfihqxZ7wKPBvf/WPLYB2FDHQRDVs4
+        uvWZZNQYqolpGkUoYNplDi2pWZPiPvbzC+AqvO4PYz+5nDeIGgQViKhMRCAn
+        FzR0HgzybN5rAnWQEUC7LQvIhFKjrKS4eA5fItpo20lYnxf8idYBkvTGJ/ul
+        jYf4nLPddWsWeSP88FW8FVfhtPrHUzGBdffSEooDM43ciXkfs9Mry8Q0y7fN
+        XZxMCspn71iHUyZRGd6xozKyoB6ZXX1+lSgoSeXXNvPpKjECr0bYJ4dj9c/F
+        KS5xCxpl5xZWkYtigw5b0oJsr+TncjAbBWUXHMvy6W0YrgNJGktmNGmfg9IK
+        nriYgRm24TPmG7MxQzAFVp13LxuzFJI7JVhqlX3InuGhu8E/W6QBdek6pXGu
+        x2uFb1B6jyOQXKf4GnvgVpfsxxvy9NSFpHDBl/5ChIKPkzfGhNz/ZKpxlhDj
+        27D3GrWRJDHRDcZEdPMnnMFRKzcjo0+mhKUun2ii9wUaY56uqntn4JDF8cxL
+        aLJ8fjG7gdnDtptOqg/O2MjIQGvZdA1Bj8vTQaE9+IVh4km+W5pD8jJvwKiB
+        0SbdFEvTeAW2bsjdlNgf7Z2dZ2+LhqgXtV/NOhxzLicy8inUekH099ntuQ9D
+        iCereFsQzpDfUfdKbFKKfm+2N5gHt93k+S95RkAgIDvFz+FRQDTkH97YcgiS
+        KSZEAWsIlxF0bZE5cmkWPLFGLv833cfoglzyBQVwPOEslK372MPf+HWrE76q
+        pHVyuV4F9BQK0CPqsGqIYiM92qtcn7nScPggvDrzjcmFX215pRMxVbDjzqw9
+        14uXK9B0pF0Gbf5DA9gyMsN5pTAVsDMVUBKOk4L1jvEPI6fdrOjc0HicMlKT
+        CNgr/L7fOVhIYOcB+VvvbZ6mOAT1D01wcxoKI0/be6ZPQjIhvUt+s3GPpX6/
+        571gkgPQQmlOD6QHcP+KVsxFi59CPCDUQyZWGHIk3gT0FOaRYprokb0yR1du
+        ARUHaPGk8BvUTedP0VRU+9hzrLbK7d14kv1wwQqmsvcQKZXQj6xQsTzqUSqQ
+        vucQNBCKcvw6Ie4BYdgOUv/CWo2bkN908v3snRVvSc4jKrlPeg9kyE4txjCj
+        xyEiZb8Du9kuhdAmkNbqU8fqfDfiWFY2w9fP669SrN9UGOXyZmYOarfGf/2N
+        i03+M5mQzWC/W6EIQWVj/t7jOM8m5+CTDL+DOMK9h3E0nDPAuVZvDlEjxCSh
+        Ec1yir7Q26hNqyp15rdThB4WF3bw49QckJQVlI9V2LWFGl3oKPXVaEpsBxDV
+        nOTHjoSWjYzFe7JPMd8lIdp96l+94DO6nezjtkE2J5QEfnpCV+DqlcoFv1KW
+        P7LzE+ezDlVokb8JSpZHw307p/ILUVXnH2npCUKSR8AE5oVbBr986epMmWUA
+        bTZvIT47y2u0lIIkUYkrh2lHdtnxhn+FCeTfmLCeOkwrI7TatOm3qxhx/pkN
+        wJBcg4nf6rBoYnwiO6TOZoa25bblkuxYkhv2qF6Hwc4CDwZ4y89L9puHXg/v
+        nu8yWebGITTaTy1MLKpy7SRXVASER7U0rGKqTq5eaf0L2J0Ytj/kV5oQMCHd
+        iU9ptXR1vIK9NOu+Qqmc5EUXrmFFRuSugcdRRyGTVrGt1CyUvmedjU9LRXVh
+        BrcN3h+lCyafAYnlLxMEH4ZdNHI0MxHGX7CtEaDuBZYsfXa+RdeeJZ5JxJOq
+        s8qYVQSBsd80MYzhC/DrUnP++7q+Lb8Bw9E5RB9Vg9hQ67+pGndHx5rTcoKz
+        SukWkf2oe7m1mvFcCeDnAt6yy/9+SiAR/UrbeJsz/vkYINe96m8pP+7oifpm
+        wqFWqDIaF236fXE67II+4uNBoyPbTX5C+0T6Vi7eBp68v84fTl5cVTvCCS3/
+        SfjLwU1KbQSZRC52Vf2Yq+FokGywVs+7pLTRXlQkEoGPkl4WRO3rctnhl3aC
+        mEB6ul75kLzJfiA21VlR0mPXBKW3Q+sRGvacn01Bott+oQ8arDZwwZ+SxskY
+        EHfgRyyddTefidQF69d8BnrtrN9PGu5NsIidayC6s4gfMwzLZ8qtN9C6as7A
+        mbdCu5MP2vYgVsUf0BcgwmFuRjhnC2KA8VGRe0SPgv6cyIaNYxocMlXP1tVz
+        /nqvTR79DuJd2qAfaT585ZgGtaB7+JdM/SXeU/h35xV9BEtA3ryGMHRmA2DF
+        RoKF489vD1XKJa9A+u6HSqM5K+PXOtUscZ+H6H3Gz9544OJIgkqoWedP0GwW
+        OPp0bxz+gEl1o7czFlSf+V89w8QHGjSoHRLVH0vyuOZZWZNQ7xbnHS59ICmQ
+        lDiM4nK1+KkkXM04J6wUEuc9z4uUB/rdPjx41q3mPmm4QCkeUGXVVTpr7ccP
+        zBdf7rEGYH52jDNQJm8oka78vQkVQ2zYI9+BAHZuuQiJ+Ozml1d/Y/XUQfAO
+        1c3bwvdV2Lw5yi8wZ4i0lfWNDWj3hIKfT4hYpD/azgH9i3+bp43WEjv5vnhv
+        aj9kLc1ou+248/sZdm1JWAIJxil0GldJe5iwIMyQ32HNgQf+501QDfNNMD57
+        i8ZAKto+6h3boA0AJMZOGvis8XJUNN/i3eYPLUCBeuTBCNW4F1RYt1f7jxwT
+        2SJrehnPZ+9S+cgHX5K4VNyVrVc64PJg68PXh80W3xbR++atlE165jqOH06n
+        PNLv8uPS6cCxzL6+5+PugFcKTeHa2/4cFZam3J8uYJY/M8DUUi7/fM8NMWT0
+        NXPdvCgbl/n168nl910qT/O9fA1ycP6xe0HsMAIzMEtHMSV36fm2tiyN4Yti
+        kyzC3R6aaCxjcw18IBr8LCC3TxD2+VnzPvOLNSm/tph+E/AtVnOKTYay9CCN
+        N1FHadJ1bCpO2MWk0AoS8286ZnGh2WJYeq0r9B7sNNUWB84BcRMbY72hIIX5
+        RUle2X9UroGpoWpQfViBWInn1zsNZcBYmjBMWNA2V7trDXF1LeZqN2yDj+zU
+        xotjE9PZSPWCZSSYEyPYtMysclur+gxlw0Sst1NAyArt+Vx477IoaYm/EPab
+        Z7S0Lh48IbB6OZheerwpxOzXzTcQ8x/3mfgCW3ARLC1RwZ2ONc7hs1P6kyMs
+        +qy+p//MBnD49UaGU7tzces0QTIf+Zf6pQMjE0syloPCp5Hj4HoWO8CeIm7y
+        iVUPa2yKKmymtWgKc1Et5DAGSWIonG/4Ub+8mpoiosrBlY+AtcvwKRb17OYg
+        ps75k5HPEcpT3IqJyXoKve+QjCOwc8SHBQPYiFRH+O8m87vImfQGA7XoKHJ1
+        ZiBsYSBKF4S7I2D3/g82aGKTC5cMIlU3e8qwY71jLt9ncvsZS5pcDK7pxlzH
+        W4lnkippdeAZml+cfRTZswtHhE/6RzqfljiLK5hH58oI7SQlM1Pbdhf0DLPv
+        XfAzmDk6+2bqn66TseOytGNKnz3WQ4tcQ3FlSe+DMgnqWh77cW4hq+U9Er7C
+        SvmXmgNSRXmoCH7UHobcDYu2x3KkZg+xMS45p13Iifp6pP2JPrqiu/C/wgTi
+        b0zIuOhZamEgPfdQMDu15ONg0l8X2lBdQO5bxyCp1hS0DJIRq6bcPSnz5bHM
+        k1ufVI9ik4QtVnbtth0d+jimLwzCjzUmfTqQJbmb7YZr28yktvBSK1FhwsG3
+        i5zh8VdK0gbE4Ua0BNpIsN8mWJeHHUxg8gfOsNaF4Z8WvN7V0d0H2sfKiJ0g
+        EVEPDhU1FCm4Xjx6qRcDaSggwZIjuBe9ckPWKbjYGIzsrTTdtG8YBw3dfqOq
+        vx46uDlWzG6sdpG9wR7MzywYyKIEuK+2nwiYzQ/V+z73d/Afky910yuSwXWV
+        Y1M+LK3cvFJ06eDq/eGa8RuGzk8kkxOKq+gdcPXUQtplOhVN1SwWfsY5CA8l
+        rn9fKHOzIQkZJdnAdg6ntN3j2hDUmi0wNPyKG0ue656Wdh0WrJa0UZ646gMl
+        aYsD+6QQ6GeZ6Z36bN6YFtUUEZCWQoDUKCjTuFa8X8U0WXBfyE3iPyDlUP2X
+        cQgXUuUPfpHp1BR3Y2OEKBCTZn8SNtvBrZmFL416AlNt9bWr6gKjyti1KQp/
+        Gf3d9iNt1Q+c2XGuDPWeWOF1wL0A6RSdfqjrbDobxvLe1Twx7pkA4xIfsPhe
+        Bwp3FREznT1RNY6mqfjLPrf414+rur5cEXf+OhFyT9s+5zRBe1VxPxwmo79g
+        KeqN6uILoMJmVPVOzCrNwAue/FpVjZbmqK9Zo8Ry1W0tjtbfaP3K7oj8/kK/
+        yy25pg91OYdma6rsm+jYg/KT8OnXKQG8ky6KtRgBMjUXbVF0pLHSMbfada2w
+        6SEjDEolS/MtWGUik7hV1QoE9FhQ6cPN1g6xcfttj+oQPpgeMocFYLvyyL7U
+        +wbu3mlMpt7IkTDWPSd4IcmzmR/s67sAHDGzQBrm9Em9ByyiPO6lXpLuM2qS
+        gC4erP7SP5dEuc0mXiN7OmdXypebadWRrMSWpDieEL7j2NBPfGzC8UYs1tc6
+        dba59U8oOp7tsj8/IaHh16k1hyNCOikyQz1lLWJypNgKyZCHUEuY7MZY/DAE
+        WDfSJD+ZbSPMSrcNggnXmjlYVVHtXZpCWhU2ybQrf5uNUFZFWdctMZ+8Jlnr
+        4IVOE/m8EqcZw3QCD/4+QisSSm7fH5x71c3mS8mevzxFYIWnmivwxiBqLgWU
+        5uy37SFoS+ppf31mHFgxirrS5W/tpcMbj0MFy8GeCEObXESbCmzMTBrAzpok
+        owaocffeQG2LS3T43sGGpfnsWVD2gzuNoLXFX4/RkiwatawDZ3pY4s5RZowe
+        glfRyYBrQWEigkqPmuggKxswZITPE9HFk3UXrGB6B4VeUKx6Za35/eu3XvEA
+        5A7bhO22QCamBZSVlBLK4hARingbASmPOORnQTh7J05N8nUDFtIJShBwXoM1
+        su9wpgx1OzaMNGDB3d56+2BNKbn9HVs3oHzWYaaYm0UXt5uvGoHTsNFSGYam
+        GGDoRITkBSjmmEqcmIx3w6LdC4fZAiqmErwSbhEWtLD7EoLYFU9OqcdcD3nc
+        8wr66sUTd0tEeoeDgBkTn8PtxHsqJ4rcksidbpnPLG8+t8p27S3VIHhxX/hO
+        PRQdW67h4hKpGyw576QWRc6pacbAyMadiH7zEQKn2q0Ucl+gxwTXFDiigyvI
+        kFjvzo10SSoo/S5xDJ98i5kb/CW/jaryFVx5BFM+fyGti4bVg3lDxwPBFGY5
+        4PaGapYX/j9vyAtSZLmO8dTaSnRkrxXQaAfqheM19my4bDKL/H1lhpexLwhV
+        dmHy6XmPQ9MWMyT1z4oKctaQv0nBb4+R0fLm4GV7127VmqIgMrsdC+f7yx6O
+        nEeMRQjdA1EOpZf59jHQbR5W3+Mzhg4SBXz3zJgm/Yx937nlj8WdTA2+D7tk
+        /u/hQoau7CDmcz4o+g2WabBtNKvbEVf4fl/xTxrUn9uPm8VNJIzl8c87Wn1w
+        fR/9HP7nHZh4DzRbAMax+Ou5JW6scYnM3Hl4dnvMeE6E+ZYAC2NJwFYPQka1
+        I2knmPmbxhJ3sF8sxvCerSSvLsRbiTNeE3pdBDP+YxDYMurj5AoZ+GlQ4AYY
+        3Tgez4kp919hAv5/3U3goPlOOMZYR10Ae/a431xwKv+U1nbaNIRzqcN+gpN1
+        X2rliDJ/pkkwBM6PuI+TSRfnl2ZAOALFmsJ5+D73K3a3Y6iRm3PIr3GFa/aW
+        YLC+tBll1/1mujzXEyrrQ6AUX4mwzTa46H46WxfvmFtKgs0iX6nDHX/B+8q/
+        nNgtw6hEItopIbEfZIUrYSZjW70fBnuqA+BACvBzrzMlbQ8AnTjIrZHG9osS
+        T/SFZLTuQAZ+e72y90bADyA+NEsciF9QxyLUYMDd8JsUN7e7zELF5gq+/o7s
+        mRyvOypBehmb6UwzEN921DRhnQfgSIJxviDeMaaPA9WdlSGbVSuY2T/ORzqf
+        FVNZv3CwRhY6Q2aVpjEtOBbu0AHG4ysZSZJecSxrF5x/ajU48r5h8hodFOk6
+        Qpb/lGuWHnRinJvmKf71i+TpB5hlTHXb/6jJTHbYhMEg/C695sBOyKEHhyUQ
+        9h0s9QAYQoLZAgkhUt+9rqoerfktS9Z49I2sZanRFUghmEEZgJ7XbHovDRTD
+        a3twhL1nbRNrGUKblbW1YusDo02nHtYFktk05TFeKEY7CXy2UIlia6x17Ps1
+        +b7Vg5kV3JSf1lhz9G4Xec2U4NqU9+l2mY0uXfUpdxxDN/POQLlmfx5NfZ9d
+        EfqqoHG2dVzZtI3et7bmAJtgjdCO36dRVkJ/Rt8tGKKxWhzG0Xmxz0UxD4eU
+        HyFTiOr9ubxew4XjLrU733SWsZ784bKDobOUj9wfhwZHxymUwYPWltDF8/nz
+        BBIKBJKR2z/sAWMjwy1Tjb/Es3KixeyDbu4A0tioHe/F1F6s8X9nq4JE04pr
+        lwfuDlaiByEqC4kQsTHd6uvOn9OmMKXqS1gFrB1WiU7W9Xf/r8cVLKRq95Md
+        LBzmzzaCZP6zG+2tlkPW6N1Fq70cXmJf166SV3pPcj6v0xAV52yoNpDkxHx7
+        PPnnFCIELnETxm/dB7A6PI9fiZRKfL01rhiCpzsnBC7Gy3Z5qMR2DoWhNx9O
+        7zqjM3N94JfLJPxceItLb2E2P0/h/Zyyr6uidoorRnmX3o2r/frQ3UaV6cIU
+        UfzqrYDK8yNpJN6zXg6F3hbhiScm1rJYELpyoGao3r9TWXaewDmmLfVjSS6U
+        C85vOnCbL6/XA1MTu3m2OyNJkRYM7etzcPI7ybX7d0NiG2iSnR6WwyJKi+hn
+        GR86elC0R1+NDuR539sihu+WczwBX0mlGvqklZsRP8rgWJkS95go0FcCu4f9
+        jUTKLFyV8ByXtK1OI5iYYy3L2naNeQXq76A1XW8Ag7Sokgo92XRK7DUGEs2Z
+        bL3Uh5vFNhlqOqgqiYpKCtmg2vows3VVdK1W5F8gauzqwe2Vi0/G8NoErEfs
+        GbbjVng3n0KPJQlxP04zf69tfi6T73rOZ+XkKjRl6ogXZDVtMcH8m7Wzox+9
+        gbXK6xFNRRN4qjE6sqPWmZBxqe///ywDSc/0pUVD0kYJIdCN+XlG1AlRFEXi
+        C087zHGsAfDz54/fv37/+gNE2bqPXEcAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:8e01c5e1e71a,type:mt,id:Deployment%20Status~Deployment%20Status"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '131'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '358'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAGWQy06DQABFf8XMtqZlyqPQxEUFBAoyHSlga1wMMAjybBkK
+        1Oi3240r7/KcxUnu2xfIE7AGeX2hNWvO01ymHIxFCukKknnF5hpty2aqbvbO
+        Y4T13c8/Au5BQhgB67cvwPKKdoxULVhDQZFFyHO8InDiPbiQsqe3lCl01uZv
+        BsRdeNbw5qqURDti6YD4cooFb1NgbsqEmd/5jdE9L2lywjViXGoQnBcFn0l7
+        Ttn1H842t61x7yUuCjOkIj9I0InhhhJbw45ta1DKaL9fmWZreVoTFRtSwONB
+        VkapG08xtC80ypUkHtXUShf5YWmH3uxF3DlD+aiutnKrkgqZwvKpnj4DPwor
+        4hI/3UX6QhddNDap9anrbZ7tnlzzZMiVGy1c6KdB0L/yS+kS9rMhvmoab0T+
+        9hjIUkNqZy+oUlCIvVOqZKHMsECs0hnQoN8OeXgA3+/f7794sCy2mAEAAA==
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/strings/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"fromEarliest":true,"order":"DESC","tags":"module:inventory,feed:master\\.Unnamed%20Domain,type:r,mtypes:.*\\|Deployment\\
+        Status~Deployment\\ Status\\|.*"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/metrics/availability/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"ids":["AI~R~[8e01c5e1e71a/Local~/deployment=hawkular-command-gateway-war.war]~AT~Deployment
+        Status~Deployment Status","AI~R~[8e01c5e1e71a/Local~/deployment=hawkular-metrics.ear]~AT~Deployment
+        Status~Deployment Status","AI~R~[8e01c5e1e71a/Local~/deployment=hawkular-rest-api.war]~AT~Deployment
+        Status~Deployment Status","AI~R~[8e01c5e1e71a/Local~/deployment=hawkular-status.war]~AT~Deployment
+        Status~Deployment Status","AI~R~[8e01c5e1e71a/Local~/deployment=hawkular-wildfly-agent-download.war]~AT~Deployment
+        Status~Deployment Status"],"start":null,"end":null,"limit":1,"order":"DESC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '585'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '219'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAK3RPQvCMBAG4L8iNzfa+FkLDoKL4KRupcPRnDWYNKVNDUXM
+        b7c4OOgmGW55Oe4e7rIHSAEpbPf+6LOEYl4siNOK4+RgClR+IqhWptdU2c0V
+        3a1T2LDCaI2VYCVactgzh814qNxvz3736R+dLNqu/U0gAoEWIc0eYKWm1qKu
+        IeXzdbLg8+UyiXkcwR1VRwOtq+GZP6O/oJpsI4t2TCFx01kYXDPMZljLsKcL
+        pWvf+wK/dRXG5qQSF9UzLIeYCeMqZVAEvuP025q/AIlCT8ctAwAA
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups
+    body:
+      encoding: UTF-8
+      string: '{"id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm Heap Used Alert","enabled":true,"eventType":"EVENT","description":"Jvm
+        Heap Used Alert","context":{"dataId.hm.type":"gauge","dataId.hm.prefix":"hm_g_"},"type":"GROUP","tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"firingMatch":"ANY","actions":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '335'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '529'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"MiQ-region-abc-ems-def-alert-201","name":"Jvm
+        Heap Used Alert","description":"Jvm Heap Used Alert","type":"GROUP","eventType":"EVENT","eventCategory":null,"eventText":null,"severity":"MEDIUM","context":{"dataId.hm.type":"gauge","dataId.hm.prefix":"hm_g_"},"tags":{"miq.event_type":"hawkular_alert","miq.resource_type":"MiddlewareServer"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+- request:
+    method: put
+    uri: http://localhost:8080/hawkular/alerts/triggers/groups/MiQ-region-abc-ems-def-alert-201/conditions/FIRING
+    body:
+      encoding: UTF-8
+      string: '{"conditions":[{"conditionId":null,"type":"COMPARE","operator":"GT","threshold":null,"triggerMode":"FIRING","dataId":"WildFly
+        Memory Metrics~Heap Used","data2Id":"WildFly Memory Metrics~Heap Max","data2Multiplier":0.9,"triggerId":null,"interval":null},{"conditionId":null,"type":"COMPARE","operator":"LT","threshold":null,"triggerMode":"FIRING","dataId":"WildFly
+        Memory Metrics~Heap Used","data2Id":"WildFly Memory Metrics~Heap Max","data2Multiplier":0.1,"triggerId":null,"interval":null}],"dataIdMemberMap":{}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '511'
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Jun 2017 22:04:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '699'
+    body:
+      encoding: UTF-8
+      string: '[{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-1","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"GT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.9},{"tenantId":"hawkular","triggerId":"MiQ-region-abc-ems-def-alert-201","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"hawkular-MiQ-region-abc-ems-def-alert-201-FIRING-2-2","dataId":"WildFly
+        Memory Metrics~Heap Used","operator":"LT","data2Id":"WildFly Memory Metrics~Heap
+        Max","data2Multiplier":0.1}]'
+    http_version: 
+  recorded_at: Mon, 26 Jun 2017 22:04:32 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This is a border case. Issue is discussed in ManageIQ/manageiq#10674.

@miq-bot add_label enhancement, alerts