### PR TITLE
RecursiveOpenStruct isn't needed here or anywhere in this repo

### DIFF
--- a/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_manager_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_manager_spec.rb
@@ -1,4 +1,3 @@
-require 'recursive-open-struct'
 require_relative '../../middleware_manager/hawkular_helper'
 
 describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareManager do
@@ -41,11 +40,11 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareManager do
   describe 'parse_datasource' do
     it 'handles simple data' do
       # parse_datasource(server, datasource, config)
-      datasource = RecursiveOpenStruct.new(:name => 'ruby-sample-build',
-                                           :id   => 'Local~/subsystem=datasources/data-source=ExampleDS',
-                                           :path => '/t;Hawkular'\
-                                                    "/f;#{the_feed_id}/r;Local~~"\
-                                                    '/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS')
+      datasource = double(:name => 'ruby-sample-build',
+                          :id   => 'Local~/subsystem=datasources/data-source=ExampleDS',
+                          :path => '/t;Hawkular'\
+                            "/f;#{the_feed_id}/r;Local~~"\
+                            '/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS')
       config = {
         'value' => {
           'Driver Name'    => 'h2',


### PR DESCRIPTION
For testing, doubles are more than sufficient, especially if we can
remove all usages of RecursiveOpenStruct for this repository.

Needed for https://github.com/ManageIQ/manageiq/pull/15096

It's not to say that RecursiveOpenStruct should be removed everywhere, but where we can replace the only usage of it with simpler options, it's best to remove extra dependencies.