### PR TITLE
Client error name format unification

### DIFF
--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -19,9 +19,9 @@ module ManageIQ::Providers
       connect(options).fetch_version_and_status
     rescue URI::InvalidComponentError
       raise MiqException::MiqHostError, "Host '#{hostname}' is invalid"
-    rescue ::Hawkular::BaseClient::HawkularConnectionException
+    rescue ::Hawkular::ConnectionException
       raise MiqException::MiqUnreachableError, "Unable to connect to #{hostname}:#{port}"
-    rescue ::Hawkular::BaseClient::HawkularException => he
+    rescue ::Hawkular::Exception => he
       raise MiqException::MiqInvalidCredentialsError, 'Invalid credentials' if he.status_code == 401
       raise MiqException::MiqHostError, 'Hawkular not found on host' if he.status_code == 404
       raise MiqException::MiqCommunicationsError, he.message

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -37,9 +37,9 @@ module ManageIQ::Providers
         connect(options).inventory.list_feeds
       rescue URI::InvalidComponentError
         raise MiqException::MiqHostError, "Host '#{hostname}' is invalid"
-      rescue ::Hawkular::BaseClient::HawkularConnectionException
+      rescue ::Hawkular::ConnectionException
         raise MiqException::MiqUnreachableError, "Unable to connect to #{hostname}:#{port}"
-      rescue ::Hawkular::BaseClient::HawkularException => he
+      rescue ::Hawkular::Exception => he
         raise MiqException::MiqInvalidCredentialsError, 'Invalid credentials' if he.status_code == 401
         raise MiqException::MiqHostError, 'Hawkular not found on host' if he.status_code == 404
         raise MiqException::MiqCommunicationsError, he.message

--- a/manageiq-providers-hawkular.gemspec
+++ b/manageiq-providers-hawkular.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "hawkular-client", "~> 3.0.2"
+  s.add_runtime_dependency "hawkular-client", "~> 4.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Depends on https://github.com/hawkular/hawkular-client-ruby/pull/222,
which adds new names for the errors on Hawkular ruby client.