### PR TITLE
Extending event catcher and adding targeted refresh for availabilities

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/availability_updates.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/availability_updates.rb
@@ -1,0 +1,17 @@
+module ManageIQ::Providers
+  class Hawkular::Inventory::AvailabilityUpdates
+    delegate :select, :to => :@targets
+
+    def initialize(targets)
+      @targets = targets
+    end
+
+    def name
+      "Collection of availabilities to update on inventory entities"
+    end
+
+    def id
+      "Collection: #{@targets.map(&:manager_ref)}"
+    end
+  end
+end

--- a/app/models/manageiq/providers/hawkular/inventory/availability_updates.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/availability_updates.rb
@@ -1,6 +1,9 @@
 module ManageIQ::Providers
   class Hawkular::Inventory::AvailabilityUpdates
-    delegate :select, :to => :@targets
+    attr_reader :targets
+
+    delegate :select, :to => :targets
+    delegate :<<, :to => :targets
 
     def initialize(targets)
       @targets = targets

--- a/app/models/manageiq/providers/hawkular/inventory/collector/availability_updates.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/collector/availability_updates.rb
@@ -1,0 +1,11 @@
+module ManageIQ::Providers
+  class Hawkular::Inventory::Collector::AvailabilityUpdates < ManagerRefresh::Inventory::Collector
+    def deployment_updates
+      @target.select { |item| item.association == :middleware_deployments }
+    end
+
+    def server_updates
+      @target.select { |item| item.association == :middleware_servers }
+    end
+  end
+end

--- a/app/models/manageiq/providers/hawkular/inventory/parser/availability_updates.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/availability_updates.rb
@@ -1,7 +1,15 @@
 module ManageIQ::Providers
   class Hawkular::Inventory::Parser::AvailabilityUpdates < ManagerRefresh::Inventory::Parser
     def parse
+      fetch_server_availabilities
       fetch_deployment_availabilities
+    end
+
+    def fetch_server_availabilities
+      collector.server_updates.each do |item|
+        server = persister.middleware_servers.find_or_build(item.manager_ref[:ems_ref])
+        server.properties = item.options
+      end
     end
 
     def fetch_deployment_availabilities

--- a/app/models/manageiq/providers/hawkular/inventory/parser/availability_updates.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/availability_updates.rb
@@ -1,0 +1,14 @@
+module ManageIQ::Providers
+  class Hawkular::Inventory::Parser::AvailabilityUpdates < ManagerRefresh::Inventory::Parser
+    def parse
+      fetch_deployment_availabilities
+    end
+
+    def fetch_deployment_availabilities
+      collector.deployment_updates.each do |item|
+        deployment = persister.middleware_deployments.find_or_build(item.manager_ref[:ems_ref])
+        deployment.status = item.options[:status]
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/hawkular/inventory/parser/availability_updates.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/availability_updates.rb
@@ -5,6 +5,8 @@ module ManageIQ::Providers
       fetch_deployment_availabilities
     end
 
+    private
+
     def fetch_server_availabilities
       collector.server_updates.each do |item|
         server = persister.middleware_servers.find_or_build(item.manager_ref[:ems_ref])

--- a/app/models/manageiq/providers/hawkular/inventory/persister/availability_updates.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/persister/availability_updates.rb
@@ -18,20 +18,22 @@ module ManageIQ::Providers
     def self.save_servers(ems, collection)
       ::ActiveRecord::Base.transaction do
         collection.to_a.each do |item|
+          data_to_update = item.properties.try(:slice, 'Server State', 'Availability', 'Calculated Server State')
+          next if data_to_update.blank?
+
           server = ems.middleware_servers.find_by(:ems_ref => item.manager_uuid)
           next unless server # if no matching server is in the database, there is nothing to update
 
           $mw_log.debug("EMS_#{ems.id}(Persister::AvailabilityUpdates): " \
                         "Updating status to #{item.properties} for server #{server.ems_ref}")
 
-          server.properties = {} unless server.properties
-          server.properties.merge!(item.properties)
+          server.properties = {} if server.properties.blank?
+          server.properties.merge!(data_to_update)
           server.save!
         end
       end
     end
 
-    # has_middleware_manager_servers
     has_middleware_manager_deployments(:custom_save_block => method(:save_deployments))
     has_middleware_manager_servers(:custom_save_block => method(:save_servers))
   end

--- a/app/models/manageiq/providers/hawkular/inventory/persister/availability_updates.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/persister/availability_updates.rb
@@ -1,0 +1,24 @@
+module ManageIQ::Providers
+  class Hawkular::Inventory::Persister::AvailabilityUpdates < Hawkular::Inventory::Persister::MiddlewareManager
+    def self.save_deployments(ems, collection)
+      ::ActiveRecord::Base.transaction do
+        collection.to_a.each do |item|
+          deployment = ::ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDeployment.find_by(
+            :ext_management_system => ems, :ems_ref => item.manager_uuid
+          )
+
+          next unless deployment # if deployment is not found in the database, it is ignored.
+
+          $mw_log.debug("EMS_#{ems.id}(Persister::AvailabilityUpdates): " \
+                        "Updating status #{deployment.status} -> #{item.status} for deployment #{deployment.ems_ref}")
+
+          deployment.status = item.status
+          deployment.save!
+        end
+      end
+    end
+
+    # has_middleware_manager_servers
+    has_middleware_manager_deployments(:custom_save_block => method(:save_deployments))
+  end
+end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
@@ -58,10 +58,7 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Runner <
           ManagerRefresh::Target.new(:manager     => @ems,
                                      :association => item[:association],
                                      :manager_ref => { :ems_ref => item[:ems_ref] },
-                                     :options     => {
-                                       :availability => item[:availability],
-                                       :status       => item[:status]
-                                     })
+                                     :options     => item[:data])
         end
         $mw_log.debug "#{log_prefix} Queueing refresh of #{targets.count} availabilities."
         EmsRefresh.queue_refresh(targets)

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
@@ -40,12 +40,33 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Runner <
     event_monitor_handle.start
     event_monitor_handle.each_batch do |events|
       event_monitor_running
+
+      # Separate alerts from avail updates
+      avail_updates, events = events.partition { |e| !e.kind_of?(::Hawkular::Alerts::Alert) }
+
+      # Filter and queue events for processing
       new_events = events.select { |e| whitelist?(e) }
       $mw_log.debug("#{log_prefix} Discarding events #{events - new_events}") if new_events.length < events.length
       if new_events.any?
         $mw_log.debug "#{log_prefix} Queueing events #{new_events}"
         @queue.enq new_events
       end
+
+      # Queue avail updates for processing
+      if avail_updates.any?
+        targets = avail_updates.map do |item|
+          ManagerRefresh::Target.new(:manager     => @ems,
+                                     :association => item[:association],
+                                     :manager_ref => { :ems_ref => item[:ems_ref] },
+                                     :options     => {
+                                       :availability => item[:availability],
+                                       :status       => item[:status]
+                                     })
+        end
+        $mw_log.debug "#{log_prefix} Queueing refresh of #{targets.count} availabilities."
+        EmsRefresh.queue_refresh(targets)
+      end
+
       # invoke the configured sleep before the next event fetch
       sleep_poll_normal
     end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream
   def initialize(ems)
     @ems               = ems
     @alerts_client     = ems.alerts_client
+    @metrics_client    = ems.metrics_client
     @collecting_events = false
   end
 
@@ -21,20 +22,64 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream
 
   private
 
+  def fetch
+    events = fetch_events
+    availabilities = fetch_availabilities
+
+    events.concat(availabilities)
+  end
+
   # Each fetch is performed from the time of the most recently caught event or 1 minute back for the first poll.
   # This gives us some slack if hawkular events are timestamped behind the miq server time.
   # Note: This assumes all Hawkular events at max-time T are fetched in one call. It is unlikely that there
   # would be more than one for the same millisecond, and that the query would be performed in the midst of
   # writes for the same ms. It may be a feasible scenario but I think it's unnecessary to handle it at this time.
-  def fetch
+  def fetch_events
     @start_time ||= (Time.current - 1.minute).to_i * 1000
-    $mw_log.debug "Catching Events since [#{@start_time}]"
+    $mw_log.debug "#{log_prefix} Catching Events since [#{@start_time}]"
 
     new_events = @alerts_client.list_events("startTime" => @start_time, "tags" => "miq.event_type|*", "thin" => true)
     @start_time = new_events.max_by(&:ctime).ctime + 1 unless new_events.empty? # add 1 ms to avoid dups with GTE filter
     new_events
   rescue => err
-    $mw_log.info "Error capturing events #{err}"
+    $mw_log.warn "#{log_prefix} Error capturing events #{err}"
     []
+  end
+
+  def fetch_availabilities
+    parser = ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareManager.new
+    parser.collector = ManageIQ::Providers::Hawkular::Inventory::Collector::MiddlewareManager.new(@ems, nil)
+
+    fetch_deployment_availabilities(parser)
+  end
+
+  def fetch_deployment_availabilities(parser)
+    # Get list of deployments to retrieve its availabilities
+    deploys = @ems.middleware_deployments.all
+    feeds = deploys.map(&:feed).uniq
+
+    $mw_log.debug("#{log_prefix} Retrieving availabilities for #{deploys.count} deployments in #{feeds.count} feeds.")
+
+    # Get deployment availabilities
+    avails = {}
+    parser.fetch_availabilities_for(feeds, deploys, parser.class::DEPLOYMENTS_AVAIL_TYPE_ID) do |item, avail|
+      avail_data = avail.try(:[], 'data').try(:first)
+      avails[item.id] = {
+        :ems_ref      => item.ems_ref,
+        :association  => :middleware_deployments,
+        :availability => avail_data,
+        :status       => parser.process_deployment_availability(avail_data)
+      }
+
+      # Filter out if availability is unchanged. This way, no refresh is triggered if unnecessary.
+      avails.delete(item.id) if item.status == avails[item.id][:status]
+    end
+
+    $mw_log.debug("#{log_prefix} Availability has changed for #{avails.length} deployments.")
+    avails.values
+  end
+
+  def log_prefix
+    @_log_prefix ||= "EMS_#{@ems.id}(Hawkular::EventCatcher::Stream)"
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
@@ -57,8 +57,8 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream
   end
 
   def fetch_server_availabilities(parser)
-    # For servers, it's also needed to refresh server state from inventory.
-    $mw_log.debug("#{log_prefix} Retrieving server state from Hawkular inventory")
+    # For servers, it's also needed to refresh server states from inventory.
+    $mw_log.debug("#{log_prefix} Retrieving server states from Hawkular inventory")
 
     server_states = {}
     @ems.middleware_servers.reload.each do |server|
@@ -106,7 +106,7 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream
   end
 
   def fetch_entities_availabilities(parser, entities)
-    return {} if entities.blank?
+    return [] if entities.blank?
     log_name = entities.first.class.name.demodulize
 
     # Get feeds where availabilities should be looked in.

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_deployment.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_deployment.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::MiddlewareDeployment < MiddlewareDeployment
+    AVAIL_TYPE_ID = 'Deployment%20Status~Deployment%20Status'.freeze
+
     def resource_path_for_metrics
       self.class.resource_path_for_metrics(self)
     end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_deployment.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_deployment.rb
@@ -1,5 +1,9 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::MiddlewareDeployment < MiddlewareDeployment
+    def resource_path_for_metrics
+      self.class.resource_path_for_metrics(self)
+    end
+
     def self.resource_path_for_metrics(item)
       path = ::Hawkular::Inventory::CanonicalPath.parse(item.ems_ref)
       # for subdeployments use it's parent deployment availability.

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::MiddlewareServer < MiddlewareServer
+    AVAIL_TYPE_ID = 'Server%20Availability~Server%20Availability'.freeze
+
     def feed
       CGI.unescape(super)
     end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/refresher.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/refresher.rb
@@ -1,5 +1,32 @@
 module ManageIQ::Providers::Hawkular
   class MiddlewareManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
     include ::EmsRefresh::Refreshers::EmsRefresherMixin
+
+    def preprocess_targets
+      @targets_by_ems_id.each do |ems_id, targets|
+        if targets.any? { |t| t.kind_of?(ExtManagementSystem) }
+          # If the EMS is in the list of targets, full graph refresh is done.
+          ems = @ems_by_ems_id[ems_id]
+          _log.info "Defaulting to full refresh for EMS: [#{ems.name}], id: [#{ems.id}]." if targets.length > 1
+          targets.clear << ems
+        elsif targets.any?
+          # Assuming availabilities are being refreshed (since there is no other
+          # kind of refresh for Hawkular)
+
+          # Filter out duplicated entities
+          # The reverse is to keep the most up-to-date data
+          uniq_targets = targets.reverse.uniq do |item|
+            {
+              :association => item.association,
+              :ems_ref     => item.manager_ref[:ems_ref]
+            }
+          end
+
+          # Compact all availability updates into one target
+          targets.clear
+          targets << ::ManageIQ::Providers::Hawkular::Inventory::AvailabilityUpdates.new(uniq_targets)
+        end
+      end
+    end
   end
 end

--- a/spec/contexts/targeted_avail_updates.rb
+++ b/spec/contexts/targeted_avail_updates.rb
@@ -1,0 +1,12 @@
+RSpec.shared_context 'targeted_avail_updates' do
+  let(:ems_hawkular) { FactoryGirl.create(:ems_hawkular) }
+  let(:target) { ::ManageIQ::Providers::Hawkular::Inventory::AvailabilityUpdates.new([]) }
+  let(:persister) { ::ManageIQ::Providers::Hawkular::Inventory::Persister::AvailabilityUpdates.new(ems_hawkular, target) }
+  let(:collector) { ::ManageIQ::Providers::Hawkular::Inventory::Collector::AvailabilityUpdates.new(ems_hawkular, target) }
+  let(:parser) do
+    parser = described_class.new
+    parser.collector = collector
+    parser.persister = persister
+    parser
+  end
+end

--- a/spec/models/manageiq/providers/hawkular/inventory/parser/availability_updates_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/inventory/parser/availability_updates_spec.rb
@@ -1,0 +1,97 @@
+describe ManageIQ::Providers::Hawkular::Inventory::Parser::AvailabilityUpdates do
+  describe "#parse" do
+    include_context 'targeted_avail_updates'
+
+    it "must create an item in persister with new status data for each server reported by collector" do
+      # Setup
+      avail_data = {
+        'Availability'            => 'up',
+        'Server State'            => 'running',
+        'Calculated Server State' => 'running'
+      }
+
+      target << ManagerRefresh::Target.new(
+        :manager     => ems_hawkular,
+        :association => :middleware_servers,
+        :manager_ref => { :ems_ref => 'abc' },
+        :options     => avail_data
+      )
+
+      # Try
+      parser.parse
+
+      # Verify
+      item = persister.middleware_servers.find('abc')
+      expect(item).to be
+      expect(item.manager_uuid).to eq('abc')
+      expect(item.properties).to eq(avail_data)
+
+      expect(persister.middleware_deployments.size).to be_zero
+    end
+
+    it "must create an item in persister with new status data for each deployment reported by collector" do
+      # Setup
+      target << ManagerRefresh::Target.new(
+        :manager     => ems_hawkular,
+        :association => :middleware_deployments,
+        :manager_ref => { :ems_ref => 'def' },
+        :options     => { :status => 'ready' }
+      )
+
+      # Try
+      parser.parse
+
+      # Verify
+      item = persister.middleware_deployments.find('def')
+      expect(item).to be
+      expect(item.manager_uuid).to eq('def')
+      expect(item.status).to eq('ready')
+
+      expect(persister.middleware_servers.size).to be_zero
+    end
+
+    it "must create one persister item if two servers in collector have same ems_ref" do
+      # Setup
+      target << ManagerRefresh::Target.new(
+        :manager     => ems_hawkular,
+        :association => :middleware_servers,
+        :manager_ref => { :ems_ref => 'abc' },
+        :options     => { 'Server State' => 'ok' }
+      )
+      target << ManagerRefresh::Target.new(
+        :manager     => ems_hawkular,
+        :association => :middleware_servers,
+        :manager_ref => { :ems_ref => 'abc' },
+        :options     => { 'Server State' => 'not ok' }
+      )
+
+      # Try
+      parser.parse
+
+      # Verify
+      expect(persister.middleware_servers.size).to eq(1)
+    end
+
+    it "must create one persister item if two deployments in collector have same ems_ref" do
+      # Setup
+      target << ManagerRefresh::Target.new(
+        :manager     => ems_hawkular,
+        :association => :middleware_deployments,
+        :manager_ref => { :ems_ref => 'def' },
+        :options     => { :status => 'ready' }
+      )
+      target << ManagerRefresh::Target.new(
+        :manager     => ems_hawkular,
+        :association => :middleware_deployments,
+        :manager_ref => { :ems_ref => 'def' },
+        :options     => { :status => 'not ready' }
+      )
+
+      # Try
+      parser.parse
+
+      # Verify
+      expect(persister.middleware_deployments.size).to eq(1)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_manager_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_manager_spec.rb
@@ -180,7 +180,13 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareManager do
     let(:stubbed_deployment) { OpenStruct.new(:manager_uuid => '/t;hawkular/f;f1/r;s1/r;d1') }
 
     before do
-      allow(persister_double).to receive(:middleware_deployments).and_return([stubbed_deployment])
+      deployments_collection = [stubbed_deployment]
+      deployments_collection.define_singleton_method(
+        :model_class,
+        -> { ::ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDeployment }
+      )
+
+      allow(persister_double).to receive(:middleware_deployments).and_return(deployments_collection)
       allow(parser).to receive(:fetch_availabilities_for)
         .and_yield(stubbed_deployment, stubbed_metric_data)
     end
@@ -221,7 +227,13 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareManager do
 
   describe 'fetch_server_availabilities' do
     before do
-      allow(persister_double).to receive(:middleware_servers).and_return([server])
+      server_collection = [server]
+      server_collection.define_singleton_method(
+        :model_class,
+        -> { ::ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer }
+      )
+
+      allow(persister_double).to receive(:middleware_servers).and_return(server_collection)
       allow(parser).to receive(:fetch_availabilities_for)
         .and_yield(server, stubbed_metric_data)
     end

--- a/spec/models/manageiq/providers/hawkular/inventory/persister/availability_updates_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/inventory/persister/availability_updates_spec.rb
@@ -1,0 +1,108 @@
+describe ::ManageIQ::Providers::Hawkular::Inventory::Persister::AvailabilityUpdates do
+  include_context 'targeted_avail_updates'
+
+  describe '#save_servers' do
+    let!(:db_server1) { ems_hawkular.middleware_servers.create(:ems_ref => 'server1', :feed => 'f1') }
+    let!(:db_server2) { ems_hawkular.middleware_servers.create(:ems_ref => 'server2', :feed => 'f1', :properties => { 'Server State' => 'unknown' }) }
+
+    it 'must update status of servers with no properties in database' do
+      # Set-up
+      updated_server = persister.middleware_servers.build(:ems_ref => 'server1', :properties => { 'Availability' => 'up' })
+      persister.middleware_servers << updated_server
+
+      # Try
+      described_class.save_servers(ems_hawkular, persister.middleware_servers)
+
+      # Verify
+      db_server1.reload
+      db_server2.reload
+      expect(db_server1.properties).to eq('Availability' => 'up')
+      expect(db_server2.properties).to eq('Server State' => 'unknown') # Check the other one wasn't updated
+    end
+
+    it 'must update only status related fields' do
+      # Set-up
+      db_server1.properties = { 'Some other data' => 'value' }
+      db_server1.save!
+
+      updated_server = persister.middleware_servers.build(
+        :ems_ref    => 'server1',
+        :properties => {
+          'Availability'            => 'up',
+          'spurious field'          => 'ok',
+          'Server State'            => 'running',
+          'Calculated Server State' => 'down'
+        }
+      )
+      persister.middleware_servers << updated_server
+
+      # Try
+      described_class.save_servers(ems_hawkular, persister.middleware_servers)
+
+      # Verify
+      db_server1.reload
+      expect(db_server1.properties).to eq(
+        'Availability'            => 'up',
+        'Server State'            => 'running',
+        'Calculated Server State' => 'down',
+        'Some other data'         => 'value'
+      )
+    end
+
+    it 'must ignore servers not found in database' do
+      # Set-up
+      updated_server = persister.middleware_servers.build(:ems_ref => 'server7', :properties => { 'Server State' => 'new status' })
+      persister.middleware_servers << updated_server
+
+      # Try
+      described_class.save_servers(ems_hawkular, persister.middleware_servers)
+
+      # Verify
+      db_server1.reload
+      db_server2.reload
+      expect(db_server1.properties).to be_blank
+      expect(db_server2.properties).to eq('Server State' => 'unknown')
+
+      ems_hawkular.middleware_servers.reload
+      expect(ems_hawkular.middleware_servers.count).to eq(2)
+    end
+  end
+
+  describe '#save_deployments' do
+    let!(:db_deployment1) { ems_hawkular.middleware_deployments.create(:ems_ref => 'deployment1', :status => 'old status') }
+    let!(:db_deployment2) { ems_hawkular.middleware_deployments.create(:ems_ref => 'deployment2', :status => 'old status') }
+
+    it 'must update status of specified deployments' do
+      # Set-up
+      updated_deployment = persister.middleware_deployments.build(:ems_ref => 'deployment1', :status => 'new status')
+      persister.middleware_deployments << updated_deployment
+
+      # Try
+      described_class.save_deployments(ems_hawkular, persister.middleware_deployments)
+
+      # Verify
+      db_deployment1.reload
+      db_deployment2.reload
+      expect(db_deployment1.status).to eq('new status')
+      expect(db_deployment2.status).to eq('old status')
+    end
+
+    it 'must ignore deployments not found in database' do
+      # Set-up
+      updated_deployment = persister.middleware_deployments.build(:ems_ref => 'deployment7', :status => 'new status')
+      persister.middleware_deployments << updated_deployment
+
+      # Try
+      described_class.save_deployments(ems_hawkular, persister.middleware_deployments)
+
+      # Verify
+      db_deployment1.reload
+      db_deployment2.reload
+      expect(db_deployment1.status).to eq('old status')
+      expect(db_deployment2.status).to eq('old status')
+
+      ems_hawkular.middleware_deployments.reload
+      expect(ems_hawkular.middleware_deployments.count).to eq(2)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream_spec.rb
@@ -1,16 +1,89 @@
 describe ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream do
-  subject do
+  let(:auth_token) do
+    AuthToken.new(:name     => "jdoe",
+                  :auth_key => "password",
+                  :userid   => "jdoe",
+                  :password => "password")
+  end
+
+  let(:metric_type_meta) { OpenStruct.new(:type => 't1', :id => 'mt1', :unit => 'unit1') }
+  let(:availability_metric) { { 'id' => 'm1', 'data' => [{ 'timestamp' => 400, 'value' => 'up'}] } }
+  let(:resource_metric_definition) do
+    ::Hawkular::Inventory::Metric.new(
+      {
+        'id'         => 'm1',
+        'path'       => '/t;hawkular/f;f1/r;resource1/m;1',
+        'properties' => { 'hawkular-metric-id' => 'm1' }
+      },
+      metric_type_meta
+    )
+  end
+
+  let(:ems_hawkular) do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    auth                 = AuthToken.new(:name     => "jdoe",
-                                         :auth_key => "password",
-                                         :userid   => "jdoe",
-                                         :password => "password")
-    ems                  = FactoryGirl.create(:ems_hawkular,
-                                              :hostname        => 'localhost',
-                                              :port            => 8080,
-                                              :authentications => [auth],
-                                              :zone            => zone)
-    described_class.new(ems)
+    FactoryGirl.create(:ems_hawkular,
+                       :hostname        => 'localhost',
+                       :port            => 8080,
+                       :authentications => [auth_token],
+                       :zone            => zone)
+  end
+
+  let(:stubbed_metrics_client) do
+    client = instance_double('::Hawkular::Metrics::Client')
+
+    allow(client).to receive_message_chain(:avail, :raw_data)
+      .with(['m1'], any_args).and_return([availability_metric])
+
+    client
+  end
+
+  let(:stubbed_inventory_client) do
+    client = instance_double('::Hawkular::Inventory::Client')
+
+    allow(client).to receive(:list_metrics_for_metric_type)
+      .with(hawkular_cp(:feed_id        => 'f1',
+                        :metric_type_id => ::ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer::AVAIL_TYPE_ID))
+      .and_return([resource_metric_definition])
+    allow(client).to receive(:list_metrics_for_metric_type)
+      .with(hawkular_cp(:feed_id        => 'f1',
+                        :metric_type_id => ::ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDeployment::AVAIL_TYPE_ID))
+      .and_return([resource_metric_definition])
+
+    client
+  end
+
+  let(:client_with_some_stubs) do
+    client = ::Hawkular::Client.new(
+      :entrypoint  => 'http://localhost:8080',
+      :credentials => {
+        :username => 'jdoe',
+        :password => 'password'
+      },
+      :options     => { :tenant => 'hawkular' }
+    )
+    allow(client).to receive(:metrics).and_return(stubbed_metrics_client)
+    allow(client).to receive(:inventory).and_return(stubbed_inventory_client)
+    client
+  end
+
+  subject do
+    allow(ems_hawkular).to receive(:connect).and_return(client_with_some_stubs)
+    described_class.new(ems_hawkular)
+  end
+
+  matcher :hawkular_cp do |cp_expected|
+    expected = {
+      :tenant_id        => nil,
+      :feed_id          => nil,
+      :environment_id   => nil,
+      :resource_type_id => nil,
+      :metric_type_id   => nil,
+      :resource_ids     => nil,
+      :metric_id        => nil
+    }.merge(cp_expected)
+    match do |actual|
+      expected.all? { |k, v| actual.send(k) == v }
+    end
   end
 
   context "#each_batch" do
@@ -24,18 +97,191 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream 
     end
 
     it "yields a valid event" do
+      ems_hawkular.middleware_deployments.create(:feed => 'f1', :ems_ref => '/t;hawkular/f;f1/r;resource1')
+
       # if generating a cassette the polling window is the previous 1 minute
       VCR.use_cassette(described_class.name.underscore.to_s,
-                       :decode_compressed_response     => true) do # , :record => :new_episodes) do
+                       :decode_compressed_response => true) do # , :record => :new_episodes) do
         result = []
         subject.start
         subject.each_batch do |events|
           result = events
           subject.stop
         end
-        expect(result.count).to be == 1
-        expect(result[0].tags['miq.event_type']).to eq 'hawkular_event.critical'
+        expect(result.count).to be == 2
+        expect(result.find { |item| item.kind_of?(::Hawkular::Alerts::Event) }.tags['miq.event_type']).to eq 'hawkular_event.critical'
+        expect(result.find { |item| item.kind_of?(Hash) && item[:association] == :middleware_deployments }).to_not be_blank
       end
+    end
+  end
+
+  describe "#fetch_availabilities (servers)" do
+    let!(:db_server) do
+      ems_hawkular.middleware_servers.create(
+        :feed       => 'f1',
+        :ems_ref    => '/t;hawkular/f;f1/r;resource1',
+        :properties => {
+          'Server State'            => 'running',
+          'Availability'            => 'up',
+          'Calculated Server State' => 'running'
+        }
+      )
+    end
+    let(:server_resource) do
+      ::Hawkular::Inventory::Resource.new(
+        'id'               => 'r1',
+        'path'             => db_server.ems_ref,
+        'name'             => 'server 1',
+        'resourceTypePath' => 'type_path',
+        'properties'       => { 'Server State' => 'running' }
+      )
+    end
+
+    before do
+      allow(stubbed_inventory_client).to receive(:get_resource)
+        .with(db_server.ems_ref, true)
+        .and_return(server_resource)
+    end
+
+    it "must return updated status for server without properties hash" do
+      # Set-up
+      db_server.properties = nil
+      db_server.save!
+
+      # Try
+      updates = subject.send(:fetch_availabilities)
+
+      # Verify
+      expect(updates).to eq(
+        [{
+          :ems_ref     => db_server.ems_ref,
+          :association => :middleware_servers,
+          :data        => {
+            'Server State'            => 'running',
+            'Availability'            => 'up',
+            'Calculated Server State' => 'running'
+          }
+        }]
+      )
+    end
+
+    it "must omit server with unchanged status" do
+      # Try
+      updates = subject.send(:fetch_availabilities)
+
+      # Validate
+      expect(updates).to be_blank
+    end
+
+    it "must set unknown status if server availability has expired or is not present" do
+      # Set-up
+      allow(stubbed_metrics_client).to receive_message_chain(:avail, :raw_data)
+        .with(['m1'], any_args).and_return([])
+
+      # Try
+      updates = subject.send(:fetch_availabilities)
+
+      # Verify
+      expect(updates).to eq(
+        [{
+          :ems_ref     => db_server.ems_ref,
+          :association => :middleware_servers,
+          :data        => {
+            'Server State'            => 'running',
+            'Availability'            => 'unknown',
+            'Calculated Server State' => 'unknown'
+          }
+        }]
+      )
+    end
+
+    it "must return updated state if inventory server state has changed" do
+      # Set-up
+      server_resource.properties['Server State'] = 'reload-required'
+
+      # Try
+      updates = subject.send(:fetch_availabilities)
+
+      # Verify
+      expect(updates).to eq(
+        [{
+          :ems_ref     => db_server.ems_ref,
+          :association => :middleware_servers,
+          :data        => {
+            'Server State'            => 'reload-required',
+            'Availability'            => 'up',
+            'Calculated Server State' => 'reload-required'
+          }
+        }]
+      )
+    end
+
+    it "must return updated state if availability metric has changed" do
+      # Set-up
+      availability_metric['data'][0]['value'] = 'down'
+
+      # Try
+      updates = subject.send(:fetch_availabilities)
+
+      # Verify
+      expect(updates).to eq(
+        [{
+          :ems_ref     => db_server.ems_ref,
+          :association => :middleware_servers,
+          :data        => {
+            'Server State'            => 'running',
+            'Availability'            => 'down',
+            'Calculated Server State' => 'down'
+          }
+        }]
+      )
+    end
+  end
+
+  describe "#fetch_availabilities (deployments)" do
+    let!(:db_deployment) { ems_hawkular.middleware_deployments.create(:feed => 'f1', :ems_ref => '/t;hawkular/f;f1/r;resource1', :status => 'Disabled') }
+
+    it "must return updated status for deployment whose availability has changed" do
+      # Try
+      updates = subject.send(:fetch_availabilities)
+
+      # Verify
+      expect(updates).to eq(
+        [{
+          :ems_ref     => db_deployment.ems_ref,
+          :association => :middleware_deployments,
+          :data        => { :status => 'Enabled' }
+        }]
+      )
+    end
+
+    it "must omit deployment with unchanged availability" do
+      # Set-up
+      availability_metric['data'][0]['value'] = 'down'
+
+      # Try
+      updates = subject.send(:fetch_availabilities)
+
+      # Verify
+      expect(updates).to be_blank
+    end
+
+    it "must set unknown status if deployment availability has expired or is not present" do
+      # Set-up
+      allow(stubbed_metrics_client).to receive_message_chain(:avail, :raw_data)
+        .with(['m1'], any_args).and_return([])
+
+      # Try
+      updates = subject.send(:fetch_availabilities)
+
+      # Verify
+      expect(updates).to eq(
+        [{
+          :ems_ref     => db_deployment.ems_ref,
+          :association => :middleware_deployments,
+          :data        => { :status => 'Unknown' }
+        }]
+      )
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,6 @@ VCR.configure do |config|
   config.cassette_library_dir = File.join(ManageIQ::Providers::Hawkular::Engine.root, 'spec/vcr_cassettes')
 end
 
+require 'contexts/targeted_avail_updates'
+
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
* A targeted refresh is added.
  * This targeted refresh only updates the status field of deployment entities when an availability update is received by the refresh worker.
  * Targeted refresh also updates server entities with the fetched new status.
  * No other field is updated, nor entity creation or deletion is performed. That work is left to the full graph refresh.
* Event catcher is extended to retrieve availability metrics from Hawkular for all deployments in inventory. Availabilities are "parsed" and compared against the status stored in MiQ database. Deployments whose status has changed are enqueued to be updated in the refresh worker.
* Event catcher is extended to fetch availability metrics of each inventoried server in MiQ. Also, its server state is fetched from Hawkular's inventory. A targeted refresh is queued for servers that have changed their availability or status.

With these changes, status of deployments and servers will be updated very frequently avoiding any manual refresh.