### PR TITLE
Changing bracket syntax for method/attribute syntax in update_alerts

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -440,11 +440,11 @@ module ManageIQ::Providers
       operation = args[0][:operation]
       alert = args[0][:alert]
       miq_alert = {
-        :id          => alert[:id],
-        :enabled     => alert[:enabled],
-        :description => alert[:description],
-        :conditions  => alert[:expression],
-        :based_on    => alert[:db]
+        :id          => alert.id,
+        :enabled     => alert.enabled,
+        :description => alert.description,
+        :conditions  => alert.expression,
+        :based_on    => alert.db
       }
       MiddlewareManager.find_each { |m| m.alert_manager.process_alert(operation, miq_alert) }
     end


### PR DESCRIPTION
Because of:
* https://github.com/ManageIQ/manageiq-schema/pull/49
* https://github.com/ManageIQ/manageiq/pull/15315

Usage of `alert[:expression]` no longer works. Changing everything to use method/attribute accessors.