### PR TITLE
Fixes event handling and generation of alternate machine in parser

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_manager.rb
@@ -105,7 +105,6 @@ module ManageIQ::Providers
       end
 
       def alternate_machine_id(machine_id)
-        return if machine_id.nil?
         # See the BZ #1294461 [1] for a more complete background.
         # Here, we'll try to adjust the machine ID to the format from that bug. We expect to get a string like
         # this: 2f68d133a4bc4c4bb19ecb47d344746c . For such string, we should return
@@ -113,6 +112,7 @@ module ManageIQ::Providers
         # providers store it in downcase, so, we let the upcase/downcase logic to other methods with more
         # business knowledge.
         # 1 - https://bugzilla.redhat.com/show_bug.cgi?id=1294461
+        return nil if machine_id.nil? || machine_id.length != 32 || machine_id[/\H/]
         alternate = []
         alternate << swap_part(machine_id[0, 8])
         alternate << swap_part(machine_id[8, 4])

--- a/app/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager.rb
@@ -99,10 +99,8 @@ module ManageIQ::Providers
       data_id_map = {}
       prefix = group_trigger.context['dataId.hm.prefix'].nil? ? '' : group_trigger.context['dataId.hm.prefix']
 
-      feed = CGI.escape(server.feed)
-
       group_trigger.conditions.each do |condition|
-        id_prefix = "#{prefix}MI~R~[#{feed}/#{server.nativeid}]~MT~"
+        id_prefix = "#{prefix}MI~R~[#{server.feed}/#{server.nativeid}]~MT~"
 
         data_id_map[condition.data_id] = "#{id_prefix}#{condition.data_id}"
         unless condition.data2_id.nil?

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
@@ -42,7 +42,7 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Runner <
       event_monitor_running
 
       # Separate alerts from avail updates
-      avail_updates, events = events.partition { |e| !e.kind_of?(::Hawkular::Alerts::Alert) }
+      avail_updates, events = events.partition { |e| !e.kind_of?(::Hawkular::Alerts::Event) }
 
       # Filter and queue events for processing
       new_events = events.select { |e| whitelist?(e) }

--- a/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_manager_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_manager_spec.rb
@@ -260,7 +260,7 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareManager do
     end
   end
 
-  describe 'alternate_machine_id' do
+  describe '#alternate_machine_id' do
     it 'should transform machine ID to dmidecode BIOS UUID' do
       # the /etc/machine-id is usually in downcase, and the dmidecode BIOS UUID is usually upcase
       # the alternate_machine_id should *just* swap digits, it should not handle upcase/downcase.
@@ -276,6 +276,14 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareManager do
       machine_id = '33d1682fbca44b4cb19ecb47d344746c'
       expected = '2f68d133-a4bc-4c4b-b19e-cb47d344746c'
       expect(parser.alternate_machine_id(machine_id)).to eq(expected)
+    end
+
+    it 'should reject id that is not 32 charasters length' do
+      expect(parser.alternate_machine_id('abc123')).to be_nil
+    end
+
+    it 'should reject id with non hexadecimal characters' do
+      expect(parser.alternate_machine_id('abcdef1234567890abcdef123456789P')).to be_nil
     end
   end
 

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager_spec.rb
@@ -11,7 +11,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::AlertProfileManager d
 
   let(:server) do
     FactoryGirl.create(:hawkular_middleware_server, :name => 'Serv', :ems_ref => 'c00fee',
-                       :feed => 'feed', :nativeid => 'nativeid')
+                       :feed => 'my feed', :nativeid => 'nativeid')
   end
   let(:server2) do
     FactoryGirl.create(:hawkular_middleware_server, :name => 'Serv2', :ems_ref => 'c22fee',
@@ -29,8 +29,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::AlertProfileManager d
 
   let(:expected_map_for_group_trigger) do
     {
-      'foo' => 'hm_some_prefix_MI~R~[feed/nativeid]~MT~foo',
-      'bar' => 'hm_some_prefix_MI~R~[feed/nativeid]~MT~bar',
+      'foo' => 'hm_some_prefix_MI~R~[my feed/nativeid]~MT~foo',
+      'bar' => 'hm_some_prefix_MI~R~[my feed/nativeid]~MT~bar',
     }
   end
   let!(:hawkular_alert) do


### PR DESCRIPTION
* Event catcher was testing the wrong type and events weren't being passed to miq core for handling.
* alternate_machine_id method was assuming that the recevied machine id was 32 characters length and failing when this was not the case.
* Feed id was being escaped when adding members to Hawkular alert profiles and linking the alert to the wrong metrics in some cases. Escaping is removed because isn't needed as noted in https://github.com/ManageIQ/manageiq/issues/15756#issuecomment-324452842

Event handling issue: ManageIQ/manageiq#15756