### PR TITLE
Migrate MiddlewareServer to MiddlewareServerWildfly and MiddlewareServerEap

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_manager.rb
@@ -332,12 +332,21 @@ module ManageIQ::Providers
           not_started && eap.properties[x].nil? ? _('not yet available') : eap.properties[x]
         end
 
-        inventory_object.assign_attributes(
+        attributes = {
           :name      => name || parse_standalone_server_name(eap.id),
           :type_path => eap.type_path,
           :hostname  => hostname,
           :product   => product
-        )
+        }
+
+        case product
+        when /wildfly/i
+          attributes[:type] = 'ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServerWildfly'
+        when /eap/i
+          attributes[:type] = 'ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServerEap'
+        end
+
+        inventory_object.assign_attributes(attributes)
       end
 
       def associate_with_vm(server, feed)

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server_eap.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server_eap.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers
+  class Hawkular::MiddlewareManager::MiddlewareServerEap < Hawkular::MiddlewareManager::MiddlewareServerWildfly
+  end
+end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server_wildfly.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server_wildfly.rb
@@ -1,21 +1,4 @@
 module ManageIQ::Providers
-  class Hawkular::MiddlewareManager::MiddlewareServerWildfly < MiddlewareServer
-    AVAIL_TYPE_ID = 'Server%20Availability~Server%20Availability'.freeze
-
-    has_many :middleware_diagnostic_reports, :dependent => :destroy
-
-    def feed
-      CGI.unescape(super)
-    end
-
-    def immutable?
-      properties['Immutable'] == 'true'
-    end
-
-    def enqueue_diagnostic_report(requesting_user:)
-      middleware_diagnostic_reports.create!(
-        :requesting_user => requesting_user
-      )
-    end
+  class Hawkular::MiddlewareManager::MiddlewareServerWildfly < Hawkular::MiddlewareManager::MiddlewareServer
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server_wildfly.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server_wildfly.rb
@@ -1,0 +1,21 @@
+module ManageIQ::Providers
+  class Hawkular::MiddlewareManager::MiddlewareServerWildfly < MiddlewareServer
+    AVAIL_TYPE_ID = 'Server%20Availability~Server%20Availability'.freeze
+
+    has_many :middleware_diagnostic_reports, :dependent => :destroy
+
+    def feed
+      CGI.unescape(super)
+    end
+
+    def immutable?
+      properties['Immutable'] == 'true'
+    end
+
+    def enqueue_diagnostic_report(requesting_user:)
+      middleware_diagnostic_reports.create!(
+        :requesting_user => requesting_user
+      )
+    end
+  end
+end


### PR DESCRIPTION
Sub-classing MiddlewareServer into more specific classes for Wildfly and EAP
 
Depends on: https://github.com/ManageIQ/manageiq-schema/pull/81
Depends on: https://github.com/ManageIQ/manageiq/pull/16126
Resolves: https://issues.jboss.org/browse/HAWKULAR-1248