### PR TITLE
Support for timeline events for MW Server and MW domain power operations

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -226,15 +226,23 @@ module ManageIQ::Providers
         }
 
         connection.operations(true).add_datasource(datasource_data) do |on|
+          notification_args = NotificationArgs.new(
+            :mw_op_success,
+            'Add Datasource',
+            datasource_data[:datasourceName],
+            ems_ref,
+            MiddlewareServer
+          )
+
           on.success do |data|
             _log.debug "Success on websocket-operation #{data}"
-            emit_middleware_notification(:mw_op_success, 'Add Datasource', datasource_data[:datasourceName], ems_ref,
-                                         MiddlewareServer)
+            emit_middleware_notification(notification_args)
           end
           on.failure do |error|
             _log.error 'error callback was called, reason: ' + error.to_s
-            emit_middleware_notification(:mw_op_failure, 'Add Datasource', datasource_data[:datasourceName], ems_ref,
-                                         MiddlewareServer, error.to_s)
+            notification_args.type = :mw_op_failure
+            notification_args.detailed_message = error.to_s
+            emit_middleware_notification(notification_args)
           end
         end
       end
@@ -259,15 +267,22 @@ module ManageIQ::Providers
         end
 
         connection.operations(true).add_deployment(deployment_data) do |on|
+          notification_args = NotificationArgs.new(
+            :mw_op_success,
+            'Deploy',
+            deployment_data[:destination_file_name],
+            ems_ref,
+            MiddlewareServer
+          )
           on.success do |data|
             _log.debug "Success on websocket-operation #{data}"
-            emit_middleware_notification(:mw_op_success, 'Deploy', deployment_data[:destination_file_name], ems_ref,
-                                         MiddlewareServer)
+            emit_middleware_notification(notification_args)
           end
           on.failure do |error|
             _log.error 'error callback was called, reason: ' + error.to_s
-            emit_middleware_notification(:mw_op_failure, 'Deploy', deployment_data[:destination_file_name], ems_ref,
-                                         MiddlewareServer, error.to_s)
+            notification_args.type = :mw_op_failure
+            notification_args.detailed_message = error.to_s
+            emit_middleware_notification(notification_args)
           end
         end
       end
@@ -282,13 +297,23 @@ module ManageIQ::Providers
         }
 
         connection.operations(true).undeploy(deployment_data) do |on|
+          notification_args = NotificationArgs.new(
+            :mw_op_success,
+            'Undeploy',
+            deployment_name,
+            ems_ref,
+            MiddlewareDeployment
+          )
+
           on.success do |data|
             _log.debug "Success on websocket-operation #{data}"
-            emit_middleware_notification(:mw_op_success, 'Undeploy', deployment_name, ems_ref, MiddlewareDeployment)
+            emit_middleware_notification(notification_args)
           end
           on.failure do |error|
             _log.error 'error callback was called, reason: ' + error.to_s
-            emit_middleware_notification(:mw_op_failure, 'Undeploy', deployment_name, ems_ref, MiddlewareDeployment, error.to_s)
+            notification_args.type = :mw_op_failure
+            notification_args.detailed_message = error.to_s
+            emit_middleware_notification(notification_args)
           end
         end
       end
@@ -302,15 +327,22 @@ module ManageIQ::Providers
         }
 
         connection.operations(true).disable_deployment(deployment_data) do |on|
+          notification_args = NotificationArgs.new(
+            :mw_op_success,
+            'Disable Deployment',
+            deployment_name,
+            ems_ref,
+            MiddlewareDeployment
+          )
           on.success do |data|
             _log.debug "Success on websocket-operation #{data}"
-            emit_middleware_notification(:mw_op_success, 'Disable Deployment', deployment_name, ems_ref,
-                                         MiddlewareDeployment)
+            emit_middleware_notification(notification_args)
           end
           on.failure do |error|
             _log.error 'error callback was called, reason: ' + error.to_s
-            emit_middleware_notification(:mw_op_failure, 'Disable Deployment', deployment_name, ems_ref,
-                                         MiddlewareDeployment, error.to_s)
+            notification_args.type = :mw_op_failure
+            notification_args.detailed_message = error.to_s
+            emit_middleware_notification(notification_args)
           end
         end
       end
@@ -324,15 +356,21 @@ module ManageIQ::Providers
         }
 
         connection.operations(true).enable_deployment(deployment_data) do |on|
+          notification_args = NotificationArgs.new(
+            :mw_op_success,
+            'Enable Deployment',
+            deployment_name, ems_ref,
+            MiddlewareDeployment
+          )
           on.success do |data|
             _log.debug "Success on websocket-operation #{data}"
-            emit_middleware_notification(:mw_op_success, 'Enable Deployment', deployment_name, ems_ref,
-                                         MiddlewareDeployment)
+            emit_middleware_notification(notification_args)
           end
           on.failure do |error|
             _log.error 'error callback was called, reason: ' + error.to_s
-            emit_middleware_notification(:mw_op_failure, 'Enable Deployment', deployment_name, ems_ref,
-                                         MiddlewareDeployment, error.to_s)
+            notification_args.type = :mw_op_failure
+            notification_args.detailed_message = error.to_s
+            emit_middleware_notification(notification_args)
           end
         end
       end
@@ -346,15 +384,22 @@ module ManageIQ::Providers
         }
 
         connection.operations(true).restart_deployment(deployment_data) do |on|
+          notification_args = NotificationArgs.new(
+            :mw_op_success,
+            'Restart Deployment',
+            deployment_name,
+            ems_ref,
+            MiddlewareDeployment
+          )
           on.success do |data|
             _log.debug "Success on websocket-operation #{data}"
-            emit_middleware_notification(:mw_op_success, 'Restart Deployment', deployment_name, ems_ref,
-                                         MiddlewareDeployment)
+            emit_middleware_notification(notification_args)
           end
           on.failure do |error|
             _log.error 'error callback was called, reason: ' + error.to_s
-            emit_middleware_notification(:mw_op_failure, 'Restart Deployment', deployment_name, ems_ref,
-                                         MiddlewareDeployment, error.to_s)
+            notification_args.type = :mw_op_failure
+            notification_args.detailed_message = error.to_s
+            emit_middleware_notification(notification_args)
           end
         end
       end
@@ -374,15 +419,22 @@ module ManageIQ::Providers
         }
 
         connection.operations(true).add_jdbc_driver(driver_data) do |on|
+          notification_args = NotificationArgs.new(
+            :mw_op_success,
+            'Add JDBC Driver',
+            driver_data[:driver_name],
+            ems_ref,
+            MiddlewareServer
+          )
           on.success do |data|
             _log.debug "Success on websocket-operation #{data}"
-            emit_middleware_notification(:mw_op_success, 'Add JDBC Driver', driver_data[:driver_name], ems_ref,
-                                         MiddlewareServer)
+            emit_middleware_notification(notification_args)
           end
           on.failure do |error|
             _log.error 'error callback was called, reason: ' + error.to_s
-            emit_middleware_notification(:mw_op_failure, 'Add JDBC Driver', driver_data[:driver_name], ems_ref,
-                                         MiddlewareServer, error.to_s)
+            notification_args.type = :mw_op_failure
+            notification_args.detailed_message = error.to_s
+            emit_middleware_notification(notification_args)
           end
         end
       end
@@ -390,46 +442,6 @@ module ManageIQ::Providers
 
     def remove_middleware_datasource(ems_ref)
       run_specific_operation('RemoveDatasource', ems_ref)
-    end
-
-    def emit_middleware_notification(type, op_name, op_arg, ems_ref, klass, extra_msg = nil)
-      mw_entity = klass.find_by(:ems_ref => ems_ref) unless klass == MiddlewareServer
-      mw_server = if mw_entity.nil?
-                    MiddlewareServer.find_by(:ems_ref => ems_ref)
-                  else
-                    MiddlewareServer.find_by(:id => mw_entity.server_id)
-                  end
-
-      return unless mw_server
-
-      Notification.create(
-        :type => type, :options => {
-          :op_name   => op_name,
-          :op_arg    => op_arg.nil? ? '' : op_arg,
-          :mw_server => "#{mw_server.name} (#{mw_server.feed})"
-        }
-      )
-
-      unless mw_entity
-        message = _('%{operation} operation for server %{server} %{status}') %
-                  {
-                    :operation => op_name,
-                    :server    => mw_server.name,
-                    :status    => type == :mw_op_success ? _('succeeded') : _('failed')
-                  }
-        message += ": #{extra_msg}" if extra_msg
-
-        EmsEvent.add_queue(
-          'add', id,
-          :ems_id          => id,
-          :source          => 'HAWKULAR',
-          :timestamp       => Time.zone.now,
-          :event_type      => "MwServer.#{op_name}.#{type == :mw_op_success ? 'Success' : 'Failed'}",
-          :message         => message,
-          :middleware_ref  => mw_server.ems_ref,
-          :middleware_type => 'MiddlewareServer'
-        )
-      end
     end
 
     # UI methods for determining availability of fields
@@ -524,24 +536,23 @@ module ManageIQ::Providers
     def run_operation(parameters, operation_name = nil, extra_data = {})
       with_provider_connection do |connection|
         callback = proc do |on|
+          notification_args = NotificationArgs.new(
+            :mw_op_success,
+            extra_data[:original_operation] || parameters[:operationName],
+            nil,
+            extra_data[:original_resource_path] || parameters[:resourcePath],
+            MiddlewareServer
+          )
+
           on.success do |data|
-            emit_middleware_notification(
-              :mw_op_success,
-              extra_data[:original_operation] || parameters[:operationName],
-              nil,
-              extra_data[:original_resource_path] || parameters[:resourcePath],
-              MiddlewareServer
-            )
+            _log.debug "Success on websocket-operation #{data}"
+            emit_middleware_notification(notification_args)
           end
           on.failure do |error|
-            emit_middleware_notification(
-              :mw_op_failure,
-              extra_data[:original_operation] || parameters[:operationName],
-              nil,
-              extra_data[:original_resource_path] || parameters[:resourcePath],
-              MiddlewareServer,
-              error.to_s
-            )
+            _log.error 'error callback was called, reason: ' + error.to_s
+            notification_args.type = :mw_op_failure
+            notification_args.detailed_message = error.to_s
+            emit_middleware_notification(notification_args)
           end
         end
         operation_connection = connection.operations(true)
@@ -550,6 +561,60 @@ module ManageIQ::Providers
         else
           operation_connection.invoke_specific_operation(parameters, operation_name, &callback)
         end
+      end
+    end
+
+    NotificationArgs = Struct.new(:type, :operation_name, :operation_args,
+                                  :target_resource, :entity_klass, :detailed_message) do
+      def event_type(mw_entity)
+        '%{entity_type}.%{operation}.%{status}' %
+          { :entity_type => mw_entity.kind_of?(MiddlewareServer) ? 'MwServer' : 'MwDomain',
+            :operation   => operation_name,
+            :status      => type == :mw_op_success ? 'Success' : 'Failed' }
+      end
+
+      def event_message(mw_entity)
+        message = _('%{operation} operation for %{server} %{status}') %
+                  {
+                    :operation => operation_name,
+                    :server    => mw_entity.name,
+                    :status    => type == :mw_op_success ? _('succeeded') : _('failed')
+                  }
+        message + ": #{detailed_message}" if detailed_message
+      end
+    end
+    private_constant :NotificationArgs
+
+    def emit_middleware_notification(notification_args)
+      mw_entity = notification_args.entity_klass.find_by(:ems_ref => ems_ref) unless notification_args.entity_klass == MiddlewareServer
+      mw_server = if mw_entity.nil?
+                    MiddlewareServer.find_by(:ems_ref => notification_args.target_resource) ||
+                      MiddlewareDomain.find_by(:ems_ref => notification_args.target_resource)
+                  else
+                    MiddlewareServer.find_by(:id => mw_entity.server_id)
+                  end
+
+      return unless mw_server
+
+      Notification.create(
+        :type => notification_args.type, :options => {
+          :op_name   => notification_args.operation_name,
+          :op_arg    => notification_args.operation_args || '',
+          :mw_server => "#{mw_server.name} (#{mw_server.feed})"
+        }
+      )
+
+      unless mw_entity
+        EmsEvent.add_queue(
+          'add', id,
+          :ems_id          => id,
+          :source          => 'HAWKULAR',
+          :timestamp       => Time.zone.now,
+          :event_type      => notification_args.event_type(mw_server),
+          :message         => notification_args.event_message(mw_server),
+          :middleware_ref  => mw_server.ems_ref,
+          :middleware_type => mw_server.class.name.demodulize
+        )
       end
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,6 +43,9 @@
           - MwServer.Kill.UserRequest
           - MwServer.Kill.Success
           - MwServer.Kill.Failed
+          - MwDomain.Stop.UserRequest
+          - MwDomain.Stop.Success
+          - MwDomain.Stop.Failed
     :jdr:
       :generation_timeout: 3.minutes
 :ems_refresh:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,32 @@
           - hawkular_deployment.ok
           - hawkular_deployment_remove.ok
           - hawkular_event
+        :power:
+          :critical:
+          - MwServer.Restart.UserRequest
+          - MwServer.Restart.Success
+          - MwServer.Restart.Failed
+          - MwServer.Reload.UserRequest
+          - MwServer.Reload.Success
+          - MwServer.Reload.Failed
+          - MwServer.Suspend.UserRequest
+          - MwServer.Suspend.Success
+          - MwServer.Suspend.Failed
+          - MwServer.Resume.UserRequest
+          - MwServer.Resume.Success
+          - MwServer.Resume.Failed
+          - MwServer.Shutdown.UserRequest
+          - MwServer.Shutdown.Success
+          - MwServer.Shutdown.Failed
+          - MwServer.Start.UserRequest
+          - MwServer.Start.Success
+          - MwServer.Start.Failed
+          - MwServer.Stop.UserRequest
+          - MwServer.Stop.Success
+          - MwServer.Stop.Failed
+          - MwServer.Kill.UserRequest
+          - MwServer.Kill.Success
+          - MwServer.Kill.Failed
     :jdr:
       :generation_timeout: 3.minutes
 :ems_refresh:

--- a/spec/models/manageiq/providers/hawkular/middleware_manager_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager_spec.rb
@@ -44,4 +44,101 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager do
       expect(ems_a.miq_id_prefix).not_to eq(ems_b.miq_id_prefix)
     end
   end
+
+  describe 'middleware server operations:' do
+    let(:ems) { FactoryGirl.create(:ems_hawkular) }
+    let(:mw_server) do
+      FactoryGirl.create(
+        :hawkular_middleware_server,
+        :ext_management_system => ems,
+        :ems_ref               => '/f;f1/r;server'
+      )
+    end
+    let(:mw_domain_server) do
+      FactoryGirl.create(
+        :hawkular_middleware_server,
+        :ext_management_system => ems,
+        :ems_ref               => '/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one'
+      )
+    end
+
+    before(:all) do
+      NotificationType.seed
+    end
+
+    def event_expectation(mw_server, op_name, status)
+      expect(EmsEvent).to receive(:add_queue).with(
+        'add', ems.id,
+        hash_including(
+          :ems_id          => ems.id,
+          :event_type      => "MwServer.#{op_name}.#{status}",
+          :middleware_ref  => mw_server.ems_ref,
+          :middleware_type => 'MiddlewareServer'
+        )
+      )
+    end
+
+    def notification_expectations(mw_server, op_name, type_name)
+      notification = Notification.last
+      expect(notification.notification_type.name).to eq(type_name)
+      expect(notification.options[:op_name]).to eq(op_name)
+      expect(notification.options[:mw_server]).to eq("#{mw_server.name} (#{mw_server.feed})")
+    end
+
+    %w(shutdown suspend resume reload restart stop).each do |operation|
+      it "#{operation} should create a user notificaton and timeline event on success" do
+        allow_any_instance_of(::Hawkular::Operations::Client).to receive(:invoke_generic_operation) do |_, &callback|
+          callback.perform(:success, nil)
+        end
+
+        op_name = operation.capitalize
+        event_expectation(mw_server, op_name, "Success")
+
+        ems.public_send("#{operation}_middleware_server", mw_server.ems_ref)
+        notification_expectations(mw_server, op_name.to_sym, 'mw_op_success')
+      end
+
+      it "#{operation} should create a user notificaton and timeline event on failure" do
+        allow_any_instance_of(::Hawkular::Operations::Client).to receive(:invoke_generic_operation) do |_, &callback|
+          callback.perform(:failure, 'Error')
+        end
+
+        op_name = operation.capitalize
+        event_expectation(mw_server, op_name, "Failed")
+
+        ems.public_send("#{operation}_middleware_server", mw_server.ems_ref)
+        notification_expectations(mw_server, op_name.to_sym, 'mw_op_failure')
+      end
+    end
+
+    %w(start restart stop kill).each do |operation|
+      it "domain specific '#{operation}' operation should create a user notificaton and timeline event on success" do
+        allow_any_instance_of(::Hawkular::Operations::Client).to receive(:invoke_generic_operation) do |_, &callback|
+          callback.perform(:success, nil)
+        end
+
+        op_name = operation.capitalize
+        event_expectation(mw_domain_server, op_name, "Success")
+
+        ems.public_send("#{operation}_middleware_domain_server",
+                        mw_domain_server.ems_ref.sub(/%2Fserver%3D/, '%2Fserver-config%3D'),
+                        :original_resource_path => mw_domain_server.ems_ref)
+        notification_expectations(mw_domain_server, op_name.to_sym, 'mw_op_success')
+      end
+
+      it "domain specific '#{operation}' operation should create a user notificaton and timeline event on failure" do
+        allow_any_instance_of(::Hawkular::Operations::Client).to receive(:invoke_generic_operation) do |_, &callback|
+          callback.perform(:failure, 'Error')
+        end
+
+        op_name = operation.capitalize
+        event_expectation(mw_domain_server, op_name, "Failed")
+
+        ems.public_send("#{operation}_middleware_domain_server",
+                        mw_domain_server.ems_ref.sub(/%2Fserver%3D/, '%2Fserver-config%3D'),
+                        :original_resource_path => mw_domain_server.ems_ref)
+        notification_expectations(mw_domain_server, op_name.to_sym, 'mw_op_failure')
+      end
+    end
+  end
 end


### PR DESCRIPTION
When server or domain operation is done, an event in the timeline
is logged. Either if the operation succeds of fails.

Jira: https://issues.jboss.org/browse/HAWKULAR-1249

Must be merged first: ManageIQ/manageiq-schema#86

![screenshot from 2017-10-04 12-42-09](https://user-images.githubusercontent.com/23639005/31190814-d92dc6e4-a901-11e7-96d2-bc6c41676f2c.png)


