### PR TITLE
Use base class MiddlewareDiagnosticReport so we can fully use report to display data

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_diagnostic_report.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_diagnostic_report.rb
@@ -1,15 +1,13 @@
 require 'timeout'
 
 module ManageIQ::Providers
-  class Hawkular::MiddlewareManager::MiddlewareDiagnosticReport < ApplicationRecord
-    self.table_name = 'middleware_diagnostic_reports'
+  class Hawkular::MiddlewareManager::MiddlewareDiagnosticReport < MiddlewareDiagnosticReport
 
     STATUS_QUEUED = 'Queued'.freeze
     STATUS_RUNNING = 'Running'.freeze
     STATUS_ERROR = 'Error'.freeze
     STATUS_READY = 'Ready'.freeze
 
-    belongs_to :middleware_server
     has_one :binary_blob, :as => :resource, :dependent => :destroy
 
     validates :middleware_server_id, :requesting_user, :presence => true


### PR DESCRIPTION
### Merge after https://github.com/ManageIQ/manageiq/pull/16135
As stated in PR for core repo, we have to use different base class otherwise we are unable to fully use report data and display data in table with pagination, sort and such.

While changing the base class I also altered the class MiddlewareDiagnosticReport not to include table name and belongs to, which should be part of core functionality.