### PR TITLE
[WIP] Implement generic view mapping

### DIFF
--- a/lib/manageiq-providers-hawkular.rb
+++ b/lib/manageiq-providers-hawkular.rb
@@ -1,2 +1,12 @@
-require "manageiq/providers/hawkular/engine"
-require "manageiq/providers/hawkular/version"
+require 'manageiq/providers/hawkular/engine'
+require 'manageiq/providers/hawkular/version'
+
+require 'generic_view_mapper'
+
+require 'manageiq/providers/hawkular/connection'
+require 'manageiq/providers/hawkular/resource_collection'
+
+root = File.expand_path('./manageiq/providers/hawkular', __dir__)
+Dir.glob(File.join(root, '{entities,views}', '*.rb')) do |file|
+  require file
+end

--- a/lib/manageiq/providers/hawkular/connection.rb
+++ b/lib/manageiq/providers/hawkular/connection.rb
@@ -7,18 +7,17 @@ module ManageIQ
       class Connection
         def client(client_class = ::Hawkular::Client)
           @client ||= client_class.new(
-            entrypoint: 'http://localhost:8080',
-            credentials: { username: 'jdoe', password: 'password' },
-            options: { tenant: 'hawkular' }
+            :entrypoint  => 'http://localhost:8080',
+            :credentials => { :username => 'jdoe', :password => 'password' },
+            :options     => { :tenant => 'hawkular' }
           )
         end
 
-        def get_all_resources
+        def fetch_all_resources
           feeds = client.inventory.list_feeds
 
           feeds.map do |feed|
-            resources = client.inventory
-              .list_resources_for_feed(feed, true)
+            resources = client.inventory.list_resources_for_feed(feed, true)
             ResourceCollection.new(resources).prepared
           end.flatten
         end

--- a/lib/manageiq/providers/hawkular/connection.rb
+++ b/lib/manageiq/providers/hawkular/connection.rb
@@ -1,0 +1,28 @@
+require 'hawkularclient'
+require_relative 'resource_collection'
+
+module ManageIQ
+  module Providers
+    module Hawkular
+      class Connection
+        def client(client_class = ::Hawkular::Client)
+          @client ||= client_class.new(
+            entrypoint: 'http://localhost:8080',
+            credentials: { username: 'jdoe', password: 'password' },
+            options: { tenant: 'hawkular' }
+          )
+        end
+
+        def get_all_resources
+          feeds = client.inventory.list_feeds
+
+          feeds.map do |feed|
+            resources = client.inventory
+              .list_resources_for_feed(feed, true)
+            ResourceCollection.new(resources).prepared
+          end.flatten
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/hawkular/entities/hawkular_agent.rb
+++ b/lib/manageiq/providers/hawkular/entities/hawkular_agent.rb
@@ -1,0 +1,15 @@
+require_relative 'middleware_resource'
+
+module ManageIQ
+  module Providers
+    module Hawkular
+      module Entities
+        class HawkularAgent < MiddlewareResource
+          def self.applicable?(metadata)
+            metadata[:type_path].include?('Hawkular WildFly Agent')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/hawkular/entities/java_runtime.rb
+++ b/lib/manageiq/providers/hawkular/entities/java_runtime.rb
@@ -1,0 +1,15 @@
+require_relative 'middleware_resource'
+
+module ManageIQ
+  module Providers
+    module Hawkular
+      module Entities
+        class JavaRuntime < MiddlewareResource
+          def self.applicable?(metadata)
+            metadata[:type_path].include?('Runtime MBean')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/hawkular/entities/middleware_resource.rb
+++ b/lib/manageiq/providers/hawkular/entities/middleware_resource.rb
@@ -1,0 +1,20 @@
+module ManageIQ
+  module Providers
+    module Hawkular
+      module Entities
+        class MiddlewareResource < GenericViewMapper::Entity
+          attribute :id, Integer
+          attribute :name, String
+          attribute :feed, String
+          attribute :properties, Hash[Symbol, String]
+          attribute :type_path, String
+          attribute :path, String
+
+          def self.applicable?(_)
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/hawkular/entities/middleware_resource.rb
+++ b/lib/manageiq/providers/hawkular/entities/middleware_resource.rb
@@ -3,12 +3,12 @@ module ManageIQ
     module Hawkular
       module Entities
         class MiddlewareResource < GenericViewMapper::Entity
-          attribute :id, Integer
-          attribute :name, String
-          attribute :feed, String
-          attribute :properties, Hash[Symbol, String]
-          attribute :type_path, String
-          attribute :path, String
+          attribute(:id, Integer)
+          attribute(:name, String)
+          attribute(:feed, String)
+          attribute(:properties, Hash[Symbol, String])
+          attribute(:type_path, String)
+          attribute(:path, String)
 
           def self.applicable?(_)
             true

--- a/lib/manageiq/providers/hawkular/entities/middleware_server.rb
+++ b/lib/manageiq/providers/hawkular/entities/middleware_server.rb
@@ -1,0 +1,15 @@
+require_relative 'middleware_resource'
+
+module ManageIQ
+  module Providers
+    module Hawkular
+      module Entities
+        class MiddlewareServer < MiddlewareResource
+          def self.applicable?(_)
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/hawkular/entities/operating_system.rb
+++ b/lib/manageiq/providers/hawkular/entities/operating_system.rb
@@ -1,0 +1,15 @@
+require_relative 'middleware_resource'
+
+module ManageIQ
+  module Providers
+    module Hawkular
+      module Entities
+        class OperatingSystem < MiddlewareResource
+          def self.applicable?(metadata)
+            metadata[:type_path].include?('Platform_Operating System')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/hawkular/entities/wildfly_server.rb
+++ b/lib/manageiq/providers/hawkular/entities/wildfly_server.rb
@@ -1,0 +1,38 @@
+require_relative 'middleware_server'
+
+module ManageIQ
+  module Providers
+    module Hawkular
+      module Entities
+        # A specialized version of MiddlewareServer for servers running WildFly.
+        class WildflyServer < MiddlewareServer
+          attribute :metrics, String
+          attribute :bind_address, String
+          attribute :product, String
+          attribute :version, String
+
+          # Returns if this entity is appliable for given metadata.
+          def self.applicable?(data)
+            data[:type_path].to_s.include?('WildFly Server')
+          end
+
+          def bind_address
+            properties[:bound_address]
+          end
+
+          def product
+            properties[:product_name]
+          end
+
+          def server_state
+            properties[:server_state]
+          end
+
+          def version
+            properties[:version]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/hawkular/entities/wildfly_server.rb
+++ b/lib/manageiq/providers/hawkular/entities/wildfly_server.rb
@@ -6,10 +6,10 @@ module ManageIQ
       module Entities
         # A specialized version of MiddlewareServer for servers running WildFly.
         class WildflyServer < MiddlewareServer
-          attribute :metrics, String
-          attribute :bind_address, String
-          attribute :product, String
-          attribute :version, String
+          attribute(:metrics, String)
+          attribute(:bind_address, String)
+          attribute(:product, String)
+          attribute(:version, String)
 
           # Returns if this entity is appliable for given metadata.
           def self.applicable?(data)

--- a/lib/manageiq/providers/hawkular/entity_mapper.rb
+++ b/lib/manageiq/providers/hawkular/entity_mapper.rb
@@ -1,0 +1,37 @@
+require 'uri'
+
+module ManageIQ
+  module Providers
+    module Hawkular
+      class EntityMapper
+        def self.map(data)
+          new(data).map
+        end
+
+        def initialize(data)
+          @data = data.dup.symbolize_keys
+        end
+
+        def map
+          feed = @data[:resourceTypePath]
+            .match(/;([0-9a-zA-Z]+)\/rt/)[1]
+
+          properties = @data
+            .delete(:properties)
+            .map { |(k,v)| [k.underscore.gsub(/\s/, '_'), v] }
+            .to_h
+            .symbolize_keys
+
+          {
+            id: @data.delete(:id),
+            feed: feed,
+            name: @data.delete(:name),
+            path: @data.delete(:path),
+            properties: properties,
+            type_path: URI.unescape(@data.delete(:resourceTypePath))
+          }.merge(@data)
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/hawkular/entity_mapper.rb
+++ b/lib/manageiq/providers/hawkular/entity_mapper.rb
@@ -1,4 +1,4 @@
-require 'uri'
+require 'cgi'
 
 module ManageIQ
   module Providers
@@ -13,8 +13,7 @@ module ManageIQ
         end
 
         def map
-          feed = @data[:resourceTypePath]
-            .match(/;([0-9a-zA-Z]+)\/rt/)[1]
+          feed = @data[:resourceTypePath].match(/;([0-9a-zA-Z]+)\/rt/)[1]
 
           properties = @data
             .delete(:properties)
@@ -23,12 +22,12 @@ module ManageIQ
             .symbolize_keys
 
           {
-            id: @data.delete(:id),
-            feed: feed,
-            name: @data.delete(:name),
-            path: @data.delete(:path),
-            properties: properties,
-            type_path: URI.unescape(@data.delete(:resourceTypePath))
+            :id         => @data.delete(:id),
+            :feed       => feed,
+            :name       => @data.delete(:name),
+            :path       => @data.delete(:path),
+            :properties => properties,
+            :type_path  => CGI.unescape(@data.delete(:resourceTypePath))
           }.merge(@data)
         end
       end

--- a/lib/manageiq/providers/hawkular/resource_collection.rb
+++ b/lib/manageiq/providers/hawkular/resource_collection.rb
@@ -1,0 +1,36 @@
+require_relative 'entity_mapper'
+require_relative 'entities/middleware_server'
+require_relative 'entities/wildfly_server'
+
+module ManageIQ
+  module Providers
+    module Hawkular
+      class ResourceCollection
+        attr_reader :data
+
+        def initialize(resources)
+          @data = resources.map { |r| r.instance_variable_get(:@_hash) }
+        end
+
+        def entities
+          @entities ||= data.map do |d|
+            data = EntityMapper.map(d)
+            GenericViewMapper.matcher.find_entity_for(data).new(data)
+          end
+        end
+
+        def prepared
+          servers = entities.select { |x| x.is_a? Entities::MiddlewareServer }
+          resources = (entities - servers).group_by(&:feed)
+
+
+          servers.each do |server|
+            server.properties.reverse_merge!(resources.inject({}) { |accum,el| accum.merge(el.properties)})
+          end
+
+          entities
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/hawkular/resource_collection.rb
+++ b/lib/manageiq/providers/hawkular/resource_collection.rb
@@ -13,7 +13,7 @@ module ManageIQ
         end
 
         def entities
-          @entities ||= data.map do |d|
+          @entities ||= data.flat_map do |d|
             data = EntityMapper.map(d)
             GenericViewMapper.matcher.find_entity_for(data).new(data)
           end
@@ -24,7 +24,7 @@ module ManageIQ
           resources = (entities - servers).group_by(&:feed)
 
           servers.each do |server|
-            server.properties.reverse_merge!(resources.inject({}) { |accum, el| accum.merge(el.properties) })
+            server.properties.reverse_merge!(resources[server.feed].inject({}) { |accum, el| accum.merge(el.properties) })
           end
 
           entities

--- a/lib/manageiq/providers/hawkular/resource_collection.rb
+++ b/lib/manageiq/providers/hawkular/resource_collection.rb
@@ -20,12 +20,11 @@ module ManageIQ
         end
 
         def prepared
-          servers = entities.select { |x| x.is_a? Entities::MiddlewareServer }
+          servers = entities.select { |x| x.kind_of?(Entities::MiddlewareServer) }
           resources = (entities - servers).group_by(&:feed)
 
-
           servers.each do |server|
-            server.properties.reverse_merge!(resources.inject({}) { |accum,el| accum.merge(el.properties)})
+            server.properties.reverse_merge!(resources.inject({}) { |accum, el| accum.merge(el.properties) })
           end
 
           entities

--- a/lib/manageiq/providers/hawkular/schemas/middleware_resource_view.json
+++ b/lib/manageiq/providers/hawkular/schemas/middleware_resource_view.json
@@ -1,0 +1,19 @@
+{
+  "summary": [
+    {
+      "name": "id"
+    },
+    {
+      "name": "name"
+    },
+    {
+      "name": "feed"
+    },
+    {
+      "name": "type_path"
+    },
+    {
+      "name": "path"
+    }
+  ]
+}

--- a/lib/manageiq/providers/hawkular/schemas/wildfly_server_view.json
+++ b/lib/manageiq/providers/hawkular/schemas/wildfly_server_view.json
@@ -1,0 +1,16 @@
+{
+  "summary": [
+    {
+      "name": "bind_address"
+    },
+    {
+      "name": "product"
+    },
+    {
+      "name": "version"
+    },
+    {
+      "name": "server_state"
+    }
+  ]
+}

--- a/lib/manageiq/providers/hawkular/views/middleware_resource_view.rb
+++ b/lib/manageiq/providers/hawkular/views/middleware_resource_view.rb
@@ -8,9 +8,9 @@ module ManageIQ
           root = File.expand_path('../schemas', __dir__)
           file = File.join(root, 'middleware_resource_view.json')
 
-          json File.read(file)
+          json(File.read(file))
 
-          applies_to ::ManageIQ::Providers::Hawkular::Entities::MiddlewareResource
+          applies_to(::ManageIQ::Providers::Hawkular::Entities::MiddlewareResource)
         end
       end
     end

--- a/lib/manageiq/providers/hawkular/views/middleware_resource_view.rb
+++ b/lib/manageiq/providers/hawkular/views/middleware_resource_view.rb
@@ -1,0 +1,18 @@
+require_relative '../entities/middleware_resource'
+
+module ManageIQ
+  module Providers
+    module Hawkular
+      module Views
+        class MiddlewareResourceView < GenericViewMapper::View
+          root = File.expand_path('../schemas', __dir__)
+          file = File.join(root, 'middleware_resource_view.json')
+
+          json File.read(file)
+
+          applies_to ::ManageIQ::Providers::Hawkular::Entities::MiddlewareResource
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/hawkular/views/wildfly_server_view.rb
+++ b/lib/manageiq/providers/hawkular/views/wildfly_server_view.rb
@@ -8,9 +8,10 @@ module ManageIQ
         class WildflyServerView < MiddlewareResourceView
           root = File.expand_path('../schemas', __dir__)
           file = File.join(root, 'wildfly_server_view.json')
-          json File.read(file)
 
-          applies_to ::ManageIQ::Providers::Hawkular::Entities::WildflyServer
+          json(File.read(file))
+
+          applies_to(::ManageIQ::Providers::Hawkular::Entities::WildflyServer)
         end
       end
     end

--- a/lib/manageiq/providers/hawkular/views/wildfly_server_view.rb
+++ b/lib/manageiq/providers/hawkular/views/wildfly_server_view.rb
@@ -1,0 +1,18 @@
+require_relative 'middleware_resource_view'
+require_relative '../entities/wildfly_server'
+
+module ManageIQ
+  module Providers
+    module Hawkular
+      module Views
+        class WildflyServerView < MiddlewareResourceView
+          root = File.expand_path('../schemas', __dir__)
+          file = File.join(root, 'wildfly_server_view.json')
+          json File.read(file)
+
+          applies_to ::ManageIQ::Providers::Hawkular::Entities::WildflyServer
+        end
+      end
+    end
+  end
+end

--- a/manageiq-providers-hawkular.gemspec
+++ b/manageiq-providers-hawkular.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_runtime_dependency "hawkular-client", "~> 4.1"
+  s.add_runtime_dependency "generic_view_mapper", "~> 0.1.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This is a first step into actually implementing the proof of concept into proper ManageIQ. Currently it enables rendering as json of data imported from hawkular. It is not supposed to be merged as-is, but used as a base branch to generate UI code upon (@mtho11).

To test:

```ruby
resources = ManageIQ::Providers::Hawkular::Connection.new.fetch_all_resources
```

All generated view objects respond to #as_json, hence something like
this on a controller would render all captured objects:

```ruby
def index
  render json: ManageIQ::Providers::Hawkular::Connection.new.fetch_all_resources
```