### PR TITLE
Fix min Ruby to be 2.3.1 per the recent core change, otherwise it fails

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -5,7 +5,7 @@ running for development.
 
 ## Dependencies
 
-* Ruby 2.3+ (Ruby 2.4.1 recommended)
+* Ruby 2.3.1+ (Ruby 2.4.1 recommended)
 * Bundler 1.15.3+
 * PostgreSQL 9.5+
 * Memcached


### PR DESCRIPTION
Running with Ruby 2.3.0 gives this error:
There was an error parsing `Gemfile`: Ruby versions less than 2.3.1 are unsupported!. Bundler cannot continue.
