### PR TITLE
Remove JDR operation from MiddlewareManager

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -48,8 +48,6 @@ module ManageIQ::Providers
     group_operation :suspend, 'Suspend Servers'
     group_operation :resume, 'Resume Servers'
 
-    generic_operation :create_jdr_report, 'JDR'
-
     attr_accessor :client
 
     def verify_credentials(_auth_type = nil, options = {})


### PR DESCRIPTION
Per this comment[1], it has been moved to MiddlewareDiagnosticReport model, so we can remove it safely.

[1]: https://github.com/ManageIQ/manageiq-providers-hawkular/pull/9#discussion_r146354161