### PR TITLE
Typo fixed on Live metrics name: mw_aggregated_servlet_time

### DIFF
--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
@@ -37,7 +37,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
       "WildFly Memory Metrics~NonHeap Used"                               => "mw_non_heap_used",
       "WildFly Memory Metrics~NonHeap Committed"                          => "mw_non_heap_committed",
       "WildFly Memory Metrics~Accumulated GC Duration"                    => "mw_accumulated_gc_duration",
-      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"    => "mw_agregated_servlet_time",
+      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"    => "mw_aggregated_servlet_time",
       "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"   => "mw_aggregated_servlet_request_count",
       "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"    => "mw_aggregated_expired_web_sessions",
       "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions" => "mw_aggregated_max_active_web_sessions",


### PR DESCRIPTION
It is fixed a typo on a live metric name: mw_aggregated_servlet_time
Here is the fix on the core repo: https://github.com/ManageIQ/manageiq/pull/16363

@abonas who should I ping to review this? 
And how this dependency with core repo is handled? It needs some sync with core.