### PR TITLE
Add optional validate param to raw_connect

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -78,6 +78,7 @@ module ManageIQ::Providers
       $log.error(err)
       raise MiqException::Error, 'Unable to verify credentials'
     end
+    private_class_method :connection_rescue_block
 
     def validate_authentication_status
       {:available => true, :message => nil}


### PR DESCRIPTION
When provider is added the credentials validation is newly done via `raw_connect` (class method) instead of `verify_credentials` (needed EMS object). Further reading on this change can be found here: https://github.com/ManageIQ/manageiq-ui-classic/pull/1580

Related to: https://github.com/ManageIQ/manageiq-ui-classic/pull/2577

Similar PRs for other providers:
- https://github.com/ManageIQ/manageiq-providers-azure/pull/161
- https://github.com/ManageIQ/manageiq-providers-google/pull/28
- https://github.com/ManageIQ/manageiq-providers-scvmm/pull/41
- https://github.com/ManageIQ/manageiq-providers-lenovo/pull/108
- https://github.com/ManageIQ/manageiq-providers-nuage/pull/40

**This PR enables the new workflow on provider. With this PR both workflows are available.** 