### PR TITLE
Create cert_store if it's not created before validation

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -99,6 +99,11 @@ module ManageIQ::Providers
         :username => username,
         :password => password
       }
+
+      if cert_store.kind_of?(String)
+        cert_store = Endpoint.new(:certificate_authority => cert_store).ssl_cert_store
+      end
+
       options = {
         :tenant         => 'hawkular',
         :verify_ssl     => verify_ssl_mode(security_protocol),


### PR DESCRIPTION
This fix the cert store if it's not created before call the validation method, create the endpoint and assign the certificate_authority

Related with : https://github.com/ManageIQ/manageiq-providers-hawkular/pull/100
Related with: UI https://github.com/ManageIQ/manageiq-ui-classic/pull/2577
Related with: UI https://github.com/ManageIQ/manageiq-ui-classic/pull/2660

cc @tumido , @israel-hdez 