### PR TITLE
Add test coverage for connect and verify_credentials

### DIFF
--- a/spec/custom_matchers/be_connected_to.rb
+++ b/spec/custom_matchers/be_connected_to.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :be_connected_to do |connection|
+  match do |client|
+    expect(client.state).to eq connection
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,3 +19,4 @@ require 'contexts/targeted_avail_updates'
 
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[ManageIQ::Providers::Hawkular::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[ManageIQ::Providers::Hawkular::Engine.root.join("spec/custom_matchers/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
Enhance test coverage of `MiddlewareManager` to provide test cases for:
- Connection via `:connect` method using non-ssl and ssl verification
- Credentials validation via both `:verify_credentials` and `:raw_connect` covering the exception mapping

Based on suggestion by @israel-hdez [here](https://github.com/ManageIQ/manageiq-providers-hawkular/pull/100#pullrequestreview-74590009).
A bit of competition PR to https://github.com/ManageIQ/manageiq-providers-hawkular/pull/86 from @aljesus, replacing 4 test cases with more generic ones.

Depends on https://github.com/ManageIQ/manageiq-providers-hawkular/pull/100