### PR TITLE
[WIP] Support Datasource and Messaging alerts

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -201,6 +201,7 @@ module ManageIQ::Providers
         :id                  => alert_profile_arg[:profile_id],
         :old_alerts_ids      => alert_profile_arg[:old_alerts],
         :new_alerts_ids      => alert_profile_arg[:new_alerts],
+        :resource_type       => alert_profile_arg[:new_assignments]["assign_to"],
         :old_assignments_ids => process_old_assignments_ids(alert_profile_arg[:old_assignments]),
         :new_assignments_ids => process_new_assignments_ids(alert_profile_arg[:new_assignments])
       }

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager_spec.rb
@@ -48,10 +48,11 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::AlertProfileManager d
 
       # Assume it was already assigned to Serv2, and now it's added to Serv.
       allow(client).to receive(:list_members).with(group_trigger.id).and_return([server2_member_trigger])
-      expect(subject).to receive(:create_new_member).with(group_trigger, server.id)
+      expect(subject).to receive(:create_new_member).with('middleware_server', group_trigger, server.id)
 
       subject.process_alert_profile(:update_assignments,
                                     :id => 50, :old_alerts_ids => [alert_id],
+                                    :resource_type => 'middleware_server',
                                     :old_assignments_ids => [server2.id],
                                     :new_assignments_ids => [server.id, server2.id])
     end
@@ -69,7 +70,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::AlertProfileManager d
       )
     )
 
-    subject.create_new_member(group_trigger, server.id)
+    subject.create_new_member('middleware_server', group_trigger, server.id)
   end
 
   it 'calculate_member_data_id_map' do


### PR DESCRIPTION
Working in support alerts with datasources and messaging types.

UI in [PR 2719](https://github.com/ManageIQ/manageiq-ui-classic/pull/2719) 
Fix #99 
Bugzilla [1512969](https://bugzilla.redhat.com/show_bug.cgi?id=1512969)
Bugzilla [1512953](https://bugzilla.redhat.com/show_bug.cgi?id=1512953)

## Discussion

Do you prefer  in [alert_profile_manager line 89](https://github.com/ManageIQ/manageiq-providers-hawkular/blob/master/app/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager.rb#L88)?

```ruby
server = type_resource.camelize.singularize.constantize.find(member_id)
```

```ruby
server =  case type_resource.camelize.singularize.constantize.find(member_id)
               when "middleware_datasource" then MiddlewareDatasource.find(member_id)
               when "middleware_messaging" then MiddlewareMessaging.find(member_id)
               else MiddlewareServer.find(member_id)
               end
```

I prefer the first one but I wanna know your opinion about.
