### PR TITLE
[1511961] Middleware server reports fixed after introducing STI on MiddlewareServer

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server.rb
@@ -17,5 +17,9 @@ module ManageIQ::Providers
         :requesting_user => requesting_user
       )
     end
+
+    def self.supported_models
+      @supported_models ||= ['middleware_server']
+    end
   end
 end


### PR DESCRIPTION
Overriding `supported_models` let us tell to whole MiddlewareServer inheritance that their metrics are listed in the same metrics yaml: [product/live_metrics/middleware_server.yml](https://github.com/ManageIQ/manageiq/blob/master/product/live_metrics/middleware_server.yaml).

Since right now there aren't differences - regarding to live metrics - between EAP/Wildfly there is no need to split file into 3 different ones. When new metrics introduces for only one of the middleware servers kinds, then would be time to split it.