### PR TITLE
Re-add remove datasource operation

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -48,6 +48,8 @@ module ManageIQ::Providers
     group_operation :suspend, 'Suspend Servers'
     group_operation :resume, 'Resume Servers'
 
+    specific_operation :remove_middleware_datasource, 'RemoveDatasource'
+
     attr_accessor :client
 
     def verify_credentials(_auth_type = nil, options = {})


### PR DESCRIPTION
Re-add remove datasource operation missing since https://github.com/ManageIQ/manageiq-providers-hawkular/pull/9.

Fixes: [BUG 1515285](https://bugzilla.redhat.com/show_bug.cgi?id=1515285)

I'm not sure though if this is the correct approach, or I should use a separate method in `app/models/manageiq/providers/hawkular/inventory/server_operations.rb` instead. This solution is not firing any error when run multiple times and basically in any case when the result is an error event...

@cfcosta, please review