### PR TITLE
Fix RemoveDatasource operation notification

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/operation_notification.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/operation_notification.rb
@@ -12,7 +12,7 @@ module ManageIQ
 
           def emit
             ActiveRecord::Base.connection_pool.with_connection do
-              mw_entity = args.entity_klass.find_by(:id => args.target_resource) unless args.entity_klass == MiddlewareServer
+              mw_entity = args.entity_klass.find_by(:ems_ref => args.target_resource) unless args.entity_klass == MiddlewareServer
               mw_server = if mw_entity.nil?
                             MiddlewareServer.find_by(:ems_ref => args.target_resource) ||
                               MiddlewareDomain.find_by(:ems_ref => args.target_resource)

--- a/app/models/manageiq/providers/hawkular/inventory/server_operations.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/server_operations.rb
@@ -24,10 +24,10 @@ module ManageIQ
               end
             end
 
-            def specific_operation(name, action_name, default_params = {})
+            def specific_operation(name, action_name, default_params = {}, extra_data = {})
               define_method(name) do |ref, params = {}|
                 params[:resourcePath] = ref.to_s
-                run_operation(default_params.merge(params), action_name)
+                run_operation(default_params.merge(params), action_name, extra_data)
               end
             end
           end
@@ -253,10 +253,10 @@ module ManageIQ
           def run_operation(parameters, operation_name = nil, extra_data = {})
             with_provider_connection do |connection|
               notification_args = NotificationArgs.success(
-                extra_data[:original_operation] || parameters[:operationName],
+                extra_data[:original_operation] || parameters[:operationName] || operation_name.try(:titleize),
                 nil,
                 extra_data[:original_resource_path] || parameters[:resourcePath],
-                MiddlewareServer
+                extra_data[:original_klass] || MiddlewareServer
               )
 
               operation_connection = connection.operations(true)

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -48,7 +48,7 @@ module ManageIQ::Providers
     group_operation :suspend, 'Suspend Servers'
     group_operation :resume, 'Resume Servers'
 
-    specific_operation :remove_middleware_datasource, 'RemoveDatasource'
+    specific_operation :remove_middleware_datasource, 'RemoveDatasource', {}, :original_klass => MiddlewareDatasource
 
     attr_accessor :client
 


### PR DESCRIPTION
This PR rewrites the MW datasource removal operation, so it is run against MW datasource (because it's called from MW datasource controller, not the MW server one). It ensures proper `Notification` is posted, and also fixes the notification handling for MW deployment (because solution to this problem fixes that as well)

Additional fix enhancement to #111's issue [~~BUG 1515285~~](https://bugzilla.redhat.com/show_bug.cgi?id=1515285)
Fixes [BUG 1518292](https://bugzilla.redhat.com/show_bug.cgi?id=1518292)

![image](https://user-images.githubusercontent.com/7453394/33282116-ee8c29ce-d3a7-11e7-95ca-99aa6afaf3e4.png)
