### PR TITLE
Fixing live metrics for MiddlewareServer[EAP|Wildfly] instances

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server.rb
@@ -18,6 +18,14 @@ module ManageIQ::Providers
       )
     end
 
+    def live_metrics_name
+      'middleware_server'
+    end
+
+    def chart_report_name
+      'middleware_server'
+    end
+
     def self.supported_models
       @supported_models ||= ['middleware_server']
     end


### PR DESCRIPTION
This PR is a solution for the following BZ bug
https://bugzilla.redhat.com/show_bug.cgi?id=1514124

As well, it is related to the following PR already merged: https://github.com/ManageIQ/manageiq-providers-hawkular/pull/106

The introduction of the STI for MiddlewareServer broke charts and reports up for all MW Servers. It happened because it broke a convention between class name and metrics description file. Files are named like `_middleware_server.yaml` but now, with the STI is looking for `_middleware_server_eap.yaml` and `_middleware_server_wildfly.yaml`

With this PR is also fixing Chart render problems introduced by the STI.

STI was introduced in #60 