### PR TITLE
[WIP] Indicate of MiddlewareServer of a Event

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/operation_notification.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/operation_notification.rb
@@ -33,13 +33,15 @@ module ManageIQ
               unless mw_entity
                 EmsEvent.add_queue(
                   'add', manager.id,
-                  :ems_id          => manager.id,
-                  :source          => 'HAWKULAR',
-                  :timestamp       => Time.zone.now,
-                  :event_type      => args.event_type(mw_server),
-                  :message         => args.event_message(mw_server),
-                  :middleware_ref  => mw_server.ems_ref,
-                  :middleware_type => mw_server.class.name.demodulize
+                  :ems_id                 => manager.id,
+                  :source                 => 'HAWKULAR',
+                  :timestamp              => Time.zone.now,
+                  :event_type             => args.event_type(mw_server),
+                  :message                => args.event_message(mw_server),
+                  :middleware_server_id   => mw_server.id,
+                  :middleware_server_name => mw_server.name,
+                  :middleware_ref         => mw_server.ems_ref,
+                  :middleware_type        => mw_server.class.name.demodulize
                 )
               end
             end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_diagnostic_report.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_diagnostic_report.rb
@@ -88,14 +88,16 @@ module ManageIQ::Providers
 
       EmsEvent.add_queue(
         'add', ems_id,
-        :ems_id          => ems_id,
-        :source          => 'EVM',
-        :timestamp       => Time.zone.now,
-        :event_type      => 'hawkular_event',
-        :message         => _('Generation of JDR report was requested by a user.'),
-        :middleware_ref  => middleware_server.ems_ref,
-        :middleware_type => 'MiddlewareServer',
-        :username        => requesting_user
+        :ems_id                 => ems_id,
+        :source                 => 'EVM',
+        :timestamp              => Time.zone.now,
+        :event_type             => 'hawkular_event',
+        :message                => _('Generation of JDR report was requested by a user.'),
+        :middleware_server_id   => middleware_server.id,
+        :middleware_server_name => middleware_server.name,
+        :middleware_ref         => middleware_server.ems_ref,
+        :middleware_type        => 'MiddlewareServer',
+        :username               => requesting_user
       )
 
       $mw_log.info("#{log_prefix} JDR report [#{id}] for server [#{middleware_server.ems_ref}] enqueued with job #{job.id}.")


### PR DESCRIPTION
This PR will change to try fix the link

Depends of UI [#2958](https://github.com/ManageIQ/manageiq-ui-classic/pull/2958)
We need to add more information to the events about servers (such as hostname, or make some events clickable if server already exists in the inventory).

JIRA [JMAN4-242](https://issues.jboss.org/browse/JMAN4-242)
![middleware](https://user-images.githubusercontent.com/3019213/33635092-e9081cae-da16-11e7-96ff-5d311b3987da.png)

cc @abonas 