### PR TITLE
Added Use case for suspended state in Middleware Servers

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_manager.rb
@@ -194,7 +194,7 @@ module ManageIQ::Providers
           props = server.properties
 
           props['Availability'], props['Calculated Server State'] =
-            process_server_availability(props['Server State'], availability.try(:[], 'data').try(:first))
+            process_server_availability(props['Suspend State'] == 'SUSPENDED' ? 'suspended' : props['Server State'], availability.try(:[], 'data').try(:first))
         end
       end
 


### PR DESCRIPTION
We can do this instead https://github.com/ManageIQ/manageiq-ui-classic/pull/2996

![mw_suspended](https://user-images.githubusercontent.com/3019213/34097132-3ce4bad8-e3d8-11e7-9fc0-0c38af1626b4.png)

cc @israel-hdez @tumido  Can you check if this is ok?