### PR TITLE
Set hostname in Middleware Server timeline

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/operation_notification.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/operation_notification.rb
@@ -38,6 +38,7 @@ module ManageIQ
                   :timestamp       => Time.zone.now,
                   :event_type      => args.event_type(mw_server),
                   :message         => args.event_message(mw_server),
+                  :host_name       => mw_server.kind_of?(MiddlewareServer) ? mw_server.hostname : nil,
                   :middleware_ref  => mw_server.ems_ref,
                   :middleware_type => mw_server.class.name.demodulize
                 )

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_diagnostic_report.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_diagnostic_report.rb
@@ -93,6 +93,7 @@ module ManageIQ::Providers
         :timestamp       => Time.zone.now,
         :event_type      => 'hawkular_event',
         :message         => _('Generation of JDR report was requested by a user.'),
+        :host_name       => middleware_server.kind_of?(MiddlewareServer) ? middleware_server.hostname : nil,
         :middleware_ref  => middleware_server.ems_ref,
         :middleware_type => 'MiddlewareServer',
         :username        => requesting_user


### PR DESCRIPTION
Add hostname of a Middleware Server in the UI
This depends of https://github.com/ManageIQ/manageiq-ui-classic/pull/3093

![timeline_with_hostname](https://user-images.githubusercontent.com/3019213/34098065-761e58d8-e3db-11e7-89d2-736159bf2463.png)
JIRA [JMAN4-242](https://issues.jboss.org/browse/JMAN4-242)