### PR TITLE
Add JDBC events to Timeline

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
@@ -14,12 +14,16 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Runner <
       'hawkular_datasource_remove.error',
       'hawkular_deployment.error',
       'hawkular_deployment_remove.error',
+      'hawkular_jdbc.error',
+      'hawkular_jdbc_remove.error',
       'hawkular_event.critical', # general purpose critical/summary level event
       # detail
       'hawkular_datasource.ok',
       'hawkular_datasource_remove.ok',
       'hawkular_deployment.ok',
       'hawkular_deployment_remove.ok',
+      'hawkular_jdbc.ok',
+      'hawkular_jdbc_remove.ok',
       'hawkular_event', # general purpose detail level event
       # filtered (not shown in timeline)
       'hawkular_alert'


### PR DESCRIPTION
There's one more place we require events to be specified in order to show up on the Timeline.

It might be worth thinking about getting rid of this `@whitelist` here, since we define the same events in `settings.yml` as well.

Fixes: [BUG 1515476](https://bugzilla.redhat.com/show_bug.cgi?id=1515476)

![image](https://user-images.githubusercontent.com/7453394/34107705-82799012-e3fd-11e7-8bdd-5939fc982b6f.png)
![image](https://user-images.githubusercontent.com/7453394/34107725-8d3d4c6e-e3fd-11e7-8f84-6a5cfa6dac71.png)
