### PR TITLE
[GAPRINDASHVILI] Travis - set postgres to 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - RUBY_GC_HEAP_INIT_SLOTS=600000
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 addons:
-  postgresql: '9.4'
+  postgresql: '9.5'
 install: bin/setup
 after_script: bundle exec codeclimate-test-reporter
 notifications:


### PR DESCRIPTION
Upgrading postgres to 9.5 on travis.

Related to ManageIQ/manageiq#18090

(hawkular doesn't have a master or hammer branches, so, this one is gaprindashvili-only)

@miq-bot assign simaishi